### PR TITLE
Webpack 2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -672,13 +672,13 @@
       "version": "2.1.7"
     },
     "react": {
-      "version": "15.4.1"
+      "version": "15.4.2"
     },
     "react-deep-force-update": {
       "version": "2.0.1"
     },
     "react-dom": {
-      "version": "15.4.1"
+      "version": "15.4.2"
     },
     "react-helmet": {
       "version": "3.2.2"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "express": "^4.14.0",
     "express-session": "^1.14.1",
     "express-winston": "^2.0.0",
+
     "helmet": "^3.1.0",
     "images-require-hook": "^1.0.3",
     "isomorphic-fetch": "^2.2.1",
@@ -53,8 +54,8 @@
     "parse-github-url": "^0.3.2",
     "qs": "^6.3.0",
     "raven": "^0.12.3",
-    "react": "^15.4.0",
-    "react-dom": "^15.4.0",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
     "react-helmet": "^3.1.0",
     "react-hot-loader": "^3.0.0-beta.6",
     "react-redux": "^4.4.6",
@@ -86,7 +87,7 @@
     "eslint": "^3.8.1",
     "eslint-plugin-react": "^6.4.1",
     "expect": "^1.20.2",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "^2.0.0-beta.5",
     "file-loader": "^0.9.0",
     "flux-standard-action": "^1.0.0",
     "mocha": "^3.1.2",
@@ -105,7 +106,7 @@
     "style-loader": "^0.13.1",
     "supertest": "^2.0.0",
     "url-loader": "^0.5.7",
-    "webpack": "^1.13.2",
+    "webpack": "^2.2.0",
     "webpack-dev-middleware": "^1.8.4",
     "webpack-hot-middleware": "^2.13.0"
   }

--- a/webpack/build-config.js
+++ b/webpack/build-config.js
@@ -19,6 +19,13 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
+    new webpack.LoaderOptionsPlugin({
+      options: {
+        postcss: function () {
+          return [ vars({ variables: () => sharedVars }), autoprefixer ];
+        },
+      }
+    }),
     new ExtractTextPlugin({ filename: 'style.[hash].css',  allChunks: true }),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.DedupePlugin(),
@@ -36,9 +43,6 @@ module.exports = {
   ],
   module: {
     loaders: require('./loaders-config.js')
-  },
-  postcss: function () {
-    return [ vars({ variables: () => sharedVars }), autoprefixer ];
   },
   stats: {
     colors: true,

--- a/webpack/build-config.js
+++ b/webpack/build-config.js
@@ -19,7 +19,7 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new ExtractTextPlugin('style.[hash].css', { allChunks: true }),
+    new ExtractTextPlugin({ filename: 'style.[hash].css',  allChunks: true }),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin({

--- a/webpack/dev-config.js
+++ b/webpack/dev-config.js
@@ -25,17 +25,25 @@ module.exports = {
     publicPath: `${WEBPACK_DEV_URL}/static/`
   },
   plugins: [
+    new webpack.LoaderOptionsPlugin({
+         // test: /\.xxx$/, // may apply this only for some modules
+      options: {
+        postcss: function () {
+          return [ vars({ variables: () => sharedVars }), autoprefixer ];
+        }
+      }
+    }),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
-    new ExtractTextPlugin('style.css', { allChunks: true }),
+    new ExtractTextPlugin({ filename: 'style.css', allChunks: true }),
     new AssetsPlugin()
   ],
   module: {
     loaders: require('./loaders-config.js')
   },
   devtool: 'source-map',
-  postcss: function () {
-    return [ vars({ variables: () => sharedVars }), autoprefixer ];
-  },
-  debug: true
+  // postcss: function () {
+  //   return [ vars({ variables: () => sharedVars }), autoprefixer ];
+  // },
+  //debug: true
 };

--- a/webpack/loaders-config.js
+++ b/webpack/loaders-config.js
@@ -4,16 +4,16 @@ module.exports = [
   {
     test: /\.js$/i,
     exclude: /node_modules/,
-    loaders: ['babel'],
+    loaders: ['babel-loader'],
   },
   {
     test: /\.css$/i,
-    loader: ExtractTextPlugin.extract(
-      [
+    loader: ExtractTextPlugin.extract({
+      fallbackLoader: [
         'style-loader',
         'postcss-loader'
       ].join('!'),
-      [
+      loader: [
         loader(
           'css-loader',
           [
@@ -24,7 +24,7 @@ module.exports = [
         ),
         'postcss-loader'
       ].join('!')
-    )
+    })
   },
   {
     test: /\.svg$/i,


### PR DESCRIPTION
Trying out updating to Webpack 2.

Currently this branch contains **minimal** updates to configs needed to run with Webpack 2.
Ideally configs should be properly updated according to migration guide: https://webpack.js.org/guides/migrating/

Comparison of bundling between Webpack 2 and Webpack 1 in this project is as follows:

### Dev server running

#### Webpack 1 (current)

```
webpack built e7d107579468e67c79fc in 7661ms
Hash: e7d107579468e67c79fc
Version: webpack 1.14.0
Time: 7661ms
                                     Asset       Size  Chunks             Chunk Names
icons/f54f6a4529b28f3b93b12a557d3f3322.svg  290 bytes          [emitted]  
icons/57ec0f1190dd480fe6d70dca225773bb.svg  533 bytes          [emitted]  
                                 bundle.js    2.17 MB       0  [emitted]  main
                                 style.css    22.1 kB       0  [emitted]  main
                             bundle.js.map    2.56 MB       0  [emitted]  main
                             style.css.map   86 bytes       0  [emitted]  main
```

#### Webpack 2

```
webpack built 749ee23fd3e645812027 in 8118ms
Hash: 749ee23fd3e645812027
Version: webpack 2.2.0
Time: 8118ms
                                     Asset       Size  Chunks                    Chunk Names
icons/f54f6a4529b28f3b93b12a557d3f3322.svg  290 bytes          [emitted]         
icons/57ec0f1190dd480fe6d70dca225773bb.svg  533 bytes          [emitted]         
                                 bundle.js    2.14 MB       0  [emitted]  [big]  main
                                 style.css    22.1 kB       0  [emitted]         main
                             bundle.js.map    2.58 MB       0  [emitted]         main
                             style.css.map   86 bytes       0  [emitted]         main
```

### Built bundle (prod)

#### Webpack 1

```
Hash: 9a15a61c59a1315ae9c6  
Version: webpack 1.14.0
Time: 12890ms
                                    Asset       Size  Chunks             Chunk Names
icons/f54f6a4529b28f3b93b12a557d3f3322.svg  290 bytes          [emitted]  
icons/57ec0f1190dd480fe6d70dca225773bb.svg  533 bytes          [emitted]  
           bundle.9a15a61c59a1315ae9c6.js     561 kB       0  [emitted]  main
           style.9a15a61c59a1315ae9c6.css    12.6 kB       0  [emitted]  main
```

#### Webpack 2

```
Hash: e3a8721345d282544b47                                                               
Version: webpack 2.2.0
Time: 11332ms
                                    Asset       Size  Chunks                    Chunk Names
icons/f54f6a4529b28f3b93b12a557d3f3322.svg  290 bytes          [emitted]         
icons/57ec0f1190dd480fe6d70dca225773bb.svg  533 bytes          [emitted]         
           bundle.e3a8721345d282544b47.js     565 kB       0  [emitted]  [big]  main
           style.e3a8721345d282544b47.css    22.1 kB       0  [emitted]         main
Entrypoint main [big] = bundle.e3a8721345d282544b47.js style.e3a8721345d282544b47.css
```

### Conclusion

Final production bundle.js is 4kB bigger in webpack 2 and totals of 565kB (compared to 561kB). Webpack 2 considers it big.

More importantly styles.css bundle goes up to twice the size 22.1kB compared to 12.6kB, but it seems that final file is not minified, so it's likely issue with configuration.