### PR TITLE
Returning normalized snap response from findSnap handler

### DIFF
--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -10,14 +10,12 @@ export const FETCH_BUILDS_ERROR = 'FETCH_BUILDS_ERROR';
 
 // Fetch snap info (selfLink) for given repository
 export function fetchSnap(repositoryUrl) {
-  const { fullName } = parseGitHubRepoUrl(repositoryUrl);
-  repositoryUrl = encodeURIComponent(repositoryUrl);
   return {
     payload: {
-      id: fullName
+      id: repositoryUrl
     },
     [CALL_API]: {
-      path: `/api/launchpad/snaps?repository_url=${repositoryUrl}`,
+      path: `/api/launchpad/snaps?repository_url=${encodeURIComponent(repositoryUrl)}`,
       types: [FETCH_BUILDS, FETCH_SNAP_SUCCESS]
     }
   };

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -24,8 +24,8 @@ import styles from './container.css';
 
 class BuildDetails extends Component {
   render() {
-    const { user, repository, buildId, build } = this.props;
-    const { snap, error, isFetching } = this.props.snapBuilds;
+    const { user, repository, buildId, build, snap } = this.props;
+    const { error, isFetching } = this.props.snapBuilds;
 
     const buildFailed = (build.statusMessage === 'Failed to build');
     let helpBox;
@@ -122,12 +122,12 @@ BuildDetails.propTypes = {
   }).isRequired,
   buildId: PropTypes.string.isRequired,
   build: PropTypes.object,
+  snap: PropTypes.shape({
+    selfLink: PropTypes.string.isRequired,
+    storeName: PropTypes.string.isRequired
+  }),
   snapBuilds: PropTypes.shape({
     isFetching: PropTypes.bool,
-    snap: PropTypes.shape({
-      selfLink: PropTypes.string.isRequired,
-      storeName: PropTypes.string.isRequired
-    }),
     error: PropTypes.object,
   })
 };

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -19,8 +19,8 @@ import styles from './container.css';
 
 export class Builds extends Component {
   render() {
-    const { user, repository } = this.props;
-    const { isFetching, success, error, snap, builds } = this.props.snapBuilds;
+    const { user, repository, snap } = this.props;
+    const { isFetching, success, error, builds } = this.props.snapBuilds;
 
     // only show spinner when data is loading for the first time
     const isLoading = isFetching && !success;
@@ -75,12 +75,12 @@ Builds.propTypes = {
     fullName: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired
   }).isRequired,
+  snap: PropTypes.shape({
+    selfLink: PropTypes.string.isRequired,
+    storeName: PropTypes.string.isRequired
+  }),
   snapBuilds: PropTypes.shape({
     isFetching: PropTypes.bool,
-    snap: PropTypes.shape({
-      selfLink: PropTypes.string.isRequired,
-      storeName: PropTypes.string.isRequired
-    }),
     builds: PropTypes.arrayOf(
       PropTypes.shape({
         isPublished: PropTypes.bool

--- a/src/common/containers/with-snap-builds.js
+++ b/src/common/containers/with-snap-builds.js
@@ -43,10 +43,8 @@ function withSnapBuilds(WrappedComponent) {
     }
 
     render() {
-      const { snap, ...passThroughProps } = this.props; // eslint-disable-line no-unused-vars
-
       return (this.props.snapBuilds.success || this.props.snapBuilds.error
-        ? <WrappedComponent {...passThroughProps} />
+        ? <WrappedComponent {...this.props} />
         : null
       );
     }
@@ -62,12 +60,16 @@ function withSnapBuilds(WrappedComponent) {
 
   const mapStateToProps = (state) => {
     const repository = state.repository;
+
+    // get snap for given repo
+    const snap = state.entities.snaps[repository.url];
+
     // get builds for given repo from the store or set default empty values
     const snapBuilds = state.snapBuilds[repository.fullName] || snapBuildsInitialStatus;
 
     return {
       repository,
-      snap: snapBuilds.snap,
+      snap,
       snapBuilds
     };
   };

--- a/src/common/reducers/snap-builds.js
+++ b/src/common/reducers/snap-builds.js
@@ -27,11 +27,7 @@ export function snapBuilds(state = {}, action) {
         ...state,
         [action.payload.id]: {
           ...state[action.payload.id],
-          isFetching: false,
-          // TODO
-          // in refactoring this should go to entities,
-          // or maybe shouldn't be needed at all
-          snap: action.payload.response.payload.snap
+          isFetching: false
         }
       };
     case ActionTypes.FETCH_BUILDS_SUCCESS:

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -611,18 +611,8 @@ export const findSnap = async (req, res) => {
 
     return res.status(200).send({
       status: 'success',
-      payload: {
-        code: 'snap-found',
-        snap: {
-          // TODO
-          // temporary solution until snap builds store and actions
-          // are properly refactored
-          ...normalizedSnap.entities.snaps[normalizedSnap.result],
-        }
-      }
-      // TODO
-      // after refactoring of snapBuilds should only return normalized snap
-      // without payload
+      code: 'snap-found',
+      ...normalizedSnap
     });
   } catch (error) {
     return sendError(res, error);

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -974,34 +974,32 @@ describe('The Launchpad API endpoint', () => {
         nock.cleanAll();
       });
 
-      it('should return a 200 response', (done) => {
-        supertest(app)
+      it('should return a 200 response', async () => {
+        await supertest(app)
           .get('/launchpad/snaps')
           .query({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(200, done);
+          .expect(200);
       });
 
-      it('should return a "success" status', (done) => {
-        supertest(app)
+      it('should return a "success" status', async () => {
+        await supertest(app)
           .get('/launchpad/snaps')
           .query({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(hasStatus('success'))
-          .end(done);
+          .expect(hasStatus('success'));
       });
 
-      it('should return a body with a "snap-found" message with the correct snap', (done) => {
-        supertest(app)
+      it('should return a body with a "snap-found" message with the normalized snap', async () => {
+        const res = await supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(hasMessage('snap-found'))
-          .expect((res) => {
-            expect(res.body.payload.snap).toContain({
-              gitRepoUrl: testSnaps[1].git_repository_url,
-              selfLink: testSnaps[1].self_link,
-              snapcraftData: snapcraftData
-            });
-          })
-          .end(done);
+          .query({ repository_url: 'https://github.com/anowner/aname' });
+
+        expect(res.body.code).toEqual('snap-found');
+
+        expect(res.body.entities.snaps[res.body.result]).toContain({
+          gitRepoUrl: testSnaps[1].git_repository_url,
+          selfLink: testSnaps[1].self_link,
+          snapcraftData: snapcraftData
+        });
       });
     });
 
@@ -1107,33 +1105,32 @@ describe('The Launchpad API endpoint', () => {
         resetMemcached();
       });
 
-      it('should return a 200 response', (done) => {
-        supertest(app)
+      it('should return a 200 response', async () => {
+        await supertest(app)
           .get('/launchpad/snaps')
           .query({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(200, done);
+          .expect(200);
       });
 
-      it('should return a "success" status', (done) => {
-        supertest(app)
+      it('should return a "success" status', async () => {
+        await supertest(app)
           .get('/launchpad/snaps')
           .query({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(hasStatus('success'))
-          .end(done);
+          .expect(hasStatus('success'));
       });
 
-      it('should return a body with a "snap-found" message with the correct snap', (done) => {
-        supertest(app)
+      it('should return a body with a "snap-found" message with the correct snap', async () => {
+        const res = await supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(hasMessage('snap-found'))
-          .expect((res) => {
-            expect(res.body.payload.snap).toInclude({
-              gitRepoUrl: snap.git_repository_url,
-              selfLink: snap.self_link
-            });
-          })
-          .end(done);
+          .query({ repository_url: 'https://github.com/anowner/aname' });
+
+        expect(res.body.code).toEqual('snap-found');
+
+        expect(res.body.entities.snaps[res.body.result]).toContain({
+          gitRepoUrl: snap.git_repository_url,
+          selfLink: snap.self_link,
+          snapcraftData: snapcraftData
+        });
       });
 
     });

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -64,7 +64,7 @@ describe('snap builds actions', () => {
     });
 
     it('should supply a payload containing the repo full-name', () => {
-      expect(action.payload.id).toEqual(repo);
+      expect(action.payload.id).toEqual(repositoryUrl);
     });
   });
 

--- a/test/unit/src/common/containers/t_builds.js
+++ b/test/unit/src/common/containers/t_builds.js
@@ -14,11 +14,11 @@ describe('The Builds container', function() {
       fullName: 'anowner/aname',
       url: 'https://github.com/anowner/aname'
     },
+    snap: {
+      selfLink: 'https://api.launchpad.net/devel/~anowner/+snap/aname',
+      storeName: 'test-snap'
+    },
     snapBuilds: {
-      snap: {
-        selfLink: 'https://api.launchpad.net/devel/~anowner/+snap/aname',
-        storeName: 'test-snap'
-      },
       builds: []
     }
   };

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -112,10 +112,6 @@ describe('snapBuilds reducers', () => {
     it('should stop fetching', () => {
       expect(snapBuilds(state, action)[id].isFetching).toBe(false);
     });
-
-    it('should store snap', () => {
-      expect(snapBuilds(state, action)[id].snap).toEqual(SNAP);
-    });
   });
 
   context('FETCH_BUILDS_SUCCESS', () => {


### PR DESCRIPTION
Required to properly fix #655
Also part of postponed snap-builds refactoring #639 

Response from `findSnap` handler is now normalized.
Also builds list and build details components don't rely on duplicated nested `snap` object but properly get snap from existing `entities` store.

### QA: 

This is a refactoring task, so no new features added to test.

Unit tests should obviously pass.
Also builds listing (repo details) and build details pages should load without any errors both when navigating in the app and when fully reloaded (without pre-existing state).