### PR TITLE
Show install instructions for stable release of snap

### DIFF
--- a/src/common/actions/snaps.js
+++ b/src/common/actions/snaps.js
@@ -1,4 +1,5 @@
 import 'isomorphic-fetch';
+import qs from 'qs';
 
 import { CALL_API } from '../middleware/call-api';
 
@@ -44,7 +45,10 @@ export function removeSnap(repositoryUrl) {
 }
 
 export function fetchSnapStableRelease(repositoryUrl, snapName) {
-  const query = 'channel=stable&fields=name,revision';
+  const query = qs.stringify({
+    channel: 'stable',
+    fields: 'name,revision'
+  });
 
   return {
     payload: { id: repositoryUrl },

--- a/src/common/actions/snaps.js
+++ b/src/common/actions/snaps.js
@@ -8,6 +8,9 @@ export const FETCH_SNAPS_ERROR = 'FETCH_SNAPS_ERROR';
 export const REMOVE_SNAP = 'REMOVE_SNAP';
 export const REMOVE_SNAP_SUCCESS = 'REMOVE_SNAP_SUCCESS';
 export const REMOVE_SNAP_ERROR = 'REMOVE_SNAP_ERROR';
+export const FETCH_SNAP_DETAILS = 'FETCH_SNAP_DETAILS';
+export const FETCH_SNAP_DETAILS_SUCCESS = 'FETCH_SNAP_DETAILS_SUCCESS';
+export const FETCH_SNAP_DETAILS_ERROR = 'FETCH_SNAP_DETAILS_ERROR';
 
 export function fetchUserSnaps(owner) {
   const query = `owner=${encodeURIComponent(owner)}`;
@@ -34,6 +37,22 @@ export function removeSnap(repositoryUrl) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ repository_url: repositoryUrl }),
+        credentials: 'same-origin'
+      }
+    }
+  };
+}
+
+export function fetchSnapStableRelease(repositoryUrl, snapName) {
+  const query = 'channel=stable&fields=name,revision';
+
+  return {
+    payload: { id: repositoryUrl },
+    [ CALL_API ]: {
+      types: [ FETCH_SNAP_DETAILS, FETCH_SNAP_DETAILS_SUCCESS, FETCH_SNAP_DETAILS_ERROR ],
+      path: `/api/snaps/details/${encodeURIComponent(snapName)}?${query}`,
+      options: {
+        headers: { 'Content-Type': 'application/json' },
         credentials: 'same-origin'
       }
     }

--- a/src/common/components/help/help-box.js
+++ b/src/common/components/help/help-box.js
@@ -1,11 +1,16 @@
 import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 
 import styles from './help.css';
 
 export default class HelpBox extends Component {
   render() {
+    const boxClass = classNames({
+      [styles.strip]: true,
+      [styles.flexible]: this.props.isFlex
+    });
     return (
-      <div className={ styles.strip }>
+      <div className={ boxClass }>
         {this.props.children}
       </div>
     );
@@ -13,5 +18,6 @@ export default class HelpBox extends Component {
 }
 
 HelpBox.propTypes = {
+  isFlex: PropTypes.bool,
   children: PropTypes.node.isRequired
 };

--- a/src/common/components/help/help-custom.js
+++ b/src/common/components/help/help-custom.js
@@ -1,0 +1,23 @@
+import React, { Component, PropTypes } from 'react';
+
+import { HeadingThree } from '../vanilla/heading/';
+import styles from './help.css';
+
+
+export default class HelpCustom extends Component {
+  render() {
+    const { children, headline } = this.props;
+
+    return (
+      <div className={styles.helpWrapper}>
+        <HeadingThree>{ headline }</HeadingThree>
+        {children}
+      </div>
+    );
+  }
+}
+
+HelpCustom.propTypes = {
+  headline: PropTypes.string.isRequired,
+  children: PropTypes.node
+};

--- a/src/common/components/help/help-install-snap.js
+++ b/src/common/components/help/help-install-snap.js
@@ -8,9 +8,9 @@ const HELP_INSTALL_URL = 'https://snapcraft.io/docs/core/install';
 
 export default class HelpInstallSnap extends Component {
   render() {
-    const { children, headline, name, revision } = this.props;
+    const { children, headline, name, revision, stable } = this.props;
     const revOption = revision ? `--revision=${ revision }` : '';
-    const command = children || `sudo snap install --edge ${name} ${revOption}`;
+    const command = children || `sudo snap install ${stable ? '' : '--edge '}${name} ${revOption}`;
 
     /**
     // TODO more at https://github.com/canonical-ols/build.snapcraft.io/issues/655
@@ -68,5 +68,6 @@ HelpInstallSnap.propTypes = {
     }
   },
   revision: PropTypes.number,
+  stable: PropTypes.bool,
   children: PropTypes.node
 };

--- a/src/common/components/help/help-install-snap.js
+++ b/src/common/components/help/help-install-snap.js
@@ -20,39 +20,41 @@ export default class HelpInstallSnap extends Component {
      **/
 
     return (
-      <div className={styles.helpWrapper}>
-        <HeadingThree>{ headline }</HeadingThree>
-        <pre>
-          <code className={ styles.cli }>
-            {command}
-          </code>
-        </pre>
-        { revision &&
-          <p className={ styles.p }>
-            The installed snap will not be auto-updated.
+      <div className={styles.helpFlexWrapper}>
+        <HeadingThree className={styles.helpFlexHeading}>{ headline }</HeadingThree>
+        <div className={styles.helpText}>
+          <pre>
+            <code className={ styles.cli }>
+              {command}
+            </code>
+          </pre>
+          { revision &&
+            <p className={ styles.p }>
+              The installed snap will not be auto-updated.
+            </p>
+          }
+          <p className={ styles.snapdLink }>
+            (
+            <a
+              className={ styles.external }
+              href={ HELP_INSTALL_URL }
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              Don’t have snapd installed?
+            </a>
+            )
           </p>
-        }
-        <p className={ styles.snapdLink }>
-          (
-          <a
-            className={ styles.external }
-            href={ HELP_INSTALL_URL }
-            rel="noreferrer noopener"
-            target="_blank"
-          >
-            Don’t have snapd installed?
-          </a>
-          )
-        </p>
-        <div>
-          <CopyToClipboard
-            copyme={ command }
-          />
-          {/*
-          <Tweet
-            text={ tweet }
-          />
-          */}
+          <div>
+            <CopyToClipboard
+              copyme={ command }
+            />
+            {/*
+            <Tweet
+              text={ tweet }
+            />
+            */}
+          </div>
         </div>
       </div>
     );

--- a/src/common/components/help/help-install-snap.js
+++ b/src/common/components/help/help-install-snap.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 
-import { CopyToClipboard } from '../share';
+import { CopyToClipboard, Tweet } from '../share';
 import { HeadingThree } from '../vanilla/heading/';
 import styles from './help.css';
 
@@ -12,12 +12,10 @@ export default class HelpInstallSnap extends Component {
     const revOption = revision ? `--revision=${ revision }` : '';
     const command = children || `sudo snap install ${stable ? '' : '--edge '}${name} ${revOption}`;
 
-    /**
     // TODO more at https://github.com/canonical-ols/build.snapcraft.io/issues/655
     const tweet = `Install ${name} in seconds on Linux OSes:\n`
       + `sudo snap install ${name}\n\n`
       + '(Don’t have snapd? https://snapcraft.io/docs/core/install)';
-     **/
 
     return (
       <div className={styles.helpFlexWrapper}>
@@ -49,11 +47,11 @@ export default class HelpInstallSnap extends Component {
             <CopyToClipboard
               copyme={ command }
             />
-            {/*
-            <Tweet
-              text={ tweet }
-            />
-            */}
+            { stable &&
+              <Tweet
+                text={ tweet }
+              />
+            }
           </div>
         </div>
       </div>

--- a/src/common/components/help/help.css
+++ b/src/common/components/help/help.css
@@ -1,6 +1,7 @@
 .strip {
   background-color: $light-grey;
   padding: 2rem;
+  flex: 1;
 }
 
 .helpWrapper {

--- a/src/common/components/help/help.css
+++ b/src/common/components/help/help.css
@@ -1,15 +1,28 @@
 .strip {
   background-color: $light-grey;
   padding: 2rem;
-  flex: 1;
 }
 
+.flexible {
+  display: flex;
+  flex: 1;
+}
 .helpWrapper {
   margin-bottom: 1.3rem;
 }
 
 .helpWrapper:last-child {
   margin-bottom: 0;
+}
+
+.helpFlexWrapper {
+  composes: helpWrapper;
+  display: flex;
+  flex-direction: column;
+}
+
+.helpFlexWrapper .helpFlexHeading {
+  flex: 1 0 auto;
 }
 
 .cli {

--- a/src/common/components/help/index.js
+++ b/src/common/components/help/index.js
@@ -1,9 +1,11 @@
 import HelpBox from './help-box';
+import HelpCustom from './help-custom';
 import HelpInstallSnap from './help-install-snap';
 import HelpPromoteSnap from './help-promote-snap';
 
 export {
   HelpBox,
+  HelpCustom,
   HelpInstallSnap,
   HelpPromoteSnap
 };

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router';
 import BuildHistory from '../components/build-history';
 import { Message } from '../components/forms';
 import Spinner from '../components/spinner';
-import { HelpBox, HelpInstallSnap } from '../components/help';
+import { HelpBox, HelpCustom, HelpInstallSnap } from '../components/help';
 import { HeadingOne } from '../components/vanilla/heading';
 import Badge from '../components/badge';
 import Breadcrumbs from '../components/vanilla/breadcrumbs';
@@ -14,18 +14,69 @@ import BetaNotification from '../components/beta-notification';
 
 import withRepository from './with-repository';
 import withSnapBuilds from './with-snap-builds';
+import { fetchSnapStableRelease } from '../actions/snaps';
 
 import styles from './container.css';
 
 export class Builds extends Component {
+  componentWillMount() {
+    const { url } = this.props.repository;
+    const { snap } = this.props;
+
+    if (url && snap && snap.storeName) {
+      this.props.fetchSnapStableRelease(url, snap.storeName);
+    }
+  }
+
+  renderHelpBoxes() {
+    const { snap } = this.props;
+    const { builds } = this.props.snapBuilds;
+    const isPublished = builds.some((build) => build.isPublished);
+
+    if (snap && snap.storeName && isPublished) {
+      return (
+        <div className={styles.row}>
+          <div className={styles.rowItem}>
+            <HelpBox>
+              <HelpInstallSnap
+                headline='To test the latest successful build on your cloud instance or device'
+                name={ snap.storeName }
+              />
+            </HelpBox>
+          </div>
+          <div className={styles.rowItem}>
+            { snap.stableRevision
+              ? (
+                <HelpBox>
+                  <HelpInstallSnap
+                    headline='To install the latest stable version'
+                    stable={ true }
+                    name={ snap.storeName }
+                  />
+                </HelpBox>
+              )
+              : (
+                <HelpBox>
+                  <HelpCustom headline='No stable version yet'>
+                    <p>Once you’ve promoted a build to stable, you can announce it to your users.</p>
+                  </HelpCustom>
+                </HelpBox>
+              )
+            }
+          </div>
+        </div>
+      );
+    } else {
+      return null;
+    }
+  }
+
   render() {
-    const { user, repository, snap } = this.props;
-    const { isFetching, success, error, builds } = this.props.snapBuilds;
+    const { user, repository } = this.props;
+    const { isFetching, success, error } = this.props.snapBuilds;
 
     // only show spinner when data is loading for the first time
     const isLoading = isFetching && !success;
-
-    const isPublished = builds.some((build) => build.isPublished);
 
     return (
       <div className={ styles.container }>
@@ -51,14 +102,7 @@ export class Builds extends Component {
         { error &&
           <Message status='error'>{ error.message || error }</Message>
         }
-        { snap && snap.storeName && isPublished &&
-          <HelpBox>
-            <HelpInstallSnap
-              headline='To test this snap on your PC or cloud instance:'
-              name={ snap.storeName }
-            />
-          </HelpBox>
-        }
+        { this.renderHelpBoxes() }
       </div>
     );
   }
@@ -88,7 +132,8 @@ Builds.propTypes = {
     ),
     success: PropTypes.bool,
     error: PropTypes.object
-  })
+  }),
+  fetchSnapStableRelease: PropTypes.func
 };
 
 const mapStateToProps = (state) => {
@@ -97,4 +142,10 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default withRepository(withSnapBuilds(connect(mapStateToProps)(Builds)));
+const mapDispatchToProps = (dispatch) => {
+  return {
+    fetchSnapStableRelease: (url, name) => dispatch(fetchSnapStableRelease(url, name))
+  };
+};
+
+export default withRepository(withSnapBuilds(connect(mapStateToProps, mapDispatchToProps)(Builds)));

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -37,7 +37,7 @@ export class Builds extends Component {
       return (
         <div className={styles.row}>
           <div className={styles.rowItem}>
-            <HelpBox>
+            <HelpBox isFlex>
               <HelpInstallSnap
                 headline='To test the latest successful build on your cloud instance or device'
                 name={ snap.storeName }
@@ -47,7 +47,7 @@ export class Builds extends Component {
           <div className={styles.rowItem}>
             { snap.stableRevision
               ? (
-                <HelpBox>
+                <HelpBox isFlex>
                   <HelpInstallSnap
                     headline='To install the latest stable version'
                     stable={ true }

--- a/src/common/containers/container.css
+++ b/src/common/containers/container.css
@@ -33,3 +33,18 @@
   align-items: baseline;
   justify-content: space-between;
 }
+
+.row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.rowItem {
+  display: flex;
+  flex: 1;
+  margin-right: 20px;
+}
+
+.rowItem:last-child {
+  margin-right: 0;
+}

--- a/src/common/reducers/entities/index.js
+++ b/src/common/reducers/entities/index.js
@@ -2,6 +2,8 @@ import merge from 'lodash/merge';
 
 import * as RepoActionTypes from '../../actions/repository';
 import * as RegisterNameActionTypes from '../../actions/register-name';
+import * as SnapsActionTypes from '../../actions/snaps';
+
 import repository from './repository';
 import snap from './snap';
 
@@ -29,7 +31,7 @@ export function entities(state = {
   }
 
   // update snaps on register name actions
-  if (RegisterNameActionTypes[action.type]) {
+  if (RegisterNameActionTypes[action.type] || SnapsActionTypes[action.type]) {
     // TODO refactor
     // register name actions use fullName as id instead of repo url
     const snapAction = {

--- a/src/common/reducers/entities/snap.js
+++ b/src/common/reducers/entities/snap.js
@@ -1,4 +1,5 @@
 import * as RegisterNameActionTypes from '../../actions/register-name';
+import * as SnapsActionTypes from '../../actions/snaps';
 
 export default function snap(state={}, action) {
   const { payload } = action;
@@ -45,6 +46,16 @@ export default function snap(state={}, action) {
         registerNameStatus: {
           ...registerNameInitialStatus
         }
+      };
+    case SnapsActionTypes.FETCH_SNAP_DETAILS_SUCCESS:
+      return {
+        ...state,
+        stableRevision: true
+      };
+    case SnapsActionTypes.FETCH_SNAP_DETAILS_ERROR:
+      return {
+        ...state,
+        stableRevision: false
       };
     default:
       return state;

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -27,7 +27,10 @@ export const getSnapDetails = async (req, res) => {
     });
     const json = await response.json();
 
-    res.status(response.status).send(json);
+    res.status(response.status).send({
+      status: json.error_list ? 'error' : 'success',
+      ...json
+    });
   } catch (error) {
     return res.status(500).send({
       status: 'error',

--- a/test/routes/src/server/routes/t_store.js
+++ b/test/routes/src/server/routes/t_store.js
@@ -25,50 +25,71 @@ describe('The store API endpoint', () => {
       nock.cleanAll();
     });
 
-    it('passes request through to search api', async () => {
-      api = api
-        .reply(200, { package_name: 'test' });
+    context('when API returns successful response', () => {
+      it('passes request through to search api', async () => {
+        api = api
+          .reply(200, { package_name: 'test' });
 
-      const res = await supertest(app).get(`/snaps/details/${snapName}`);
+        const res = await supertest(app).get(`/snaps/details/${snapName}`);
 
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ package_name: 'test' });
+        expect(res.status).toBe(200);
+        expect(res.body).toInclude({ package_name: 'test' });
+      });
+
+      it('returns status success', async () => {
+        api = api
+          .reply(200, { package_name: 'test' });
+
+        const res = await supertest(app).get(`/snaps/details/${snapName}`);
+
+        expect(res.body).toInclude({ status: 'success' });
+      });
+
+      it('passes request through to search api with only valid query params', async () => {
+        api = api
+          .query({ channel: 'stable' })
+          .reply(200, { package_name: 'test' });
+
+        const res = await supertest(app).get(`/snaps/details/${snapName}?channel=stable&foo=bar`);
+
+        expect(res.status).toBe(200);
+        expect(res.body).toInclude({ package_name: 'test' });
+      });
+
+      it('passes request through to search api with empty channels param', async () => {
+        api = api
+          .query({ channel: '' })
+          .reply(200, { package_name: 'test' });
+
+        const res = await supertest(app).get(`/snaps/details/${snapName}?channel=`);
+
+        expect(res.status).toBe(200);
+        expect(res.body).toInclude({ package_name: 'test' });
+      });
     });
 
-    it('passes request through to search api with only valid query params', async () => {
-      api = api
-        .query({ channel: 'stable' })
-        .reply(200, { package_name: 'test' });
-
-      const res = await supertest(app).get(`/snaps/details/${snapName}?channel=stable&foo=bar`);
-
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ package_name: 'test' });
-    });
-
-    it('passes request through to search api with empty channels param', async () => {
-      api = api
-        .query({ channel: '' })
-        .reply(200, { package_name: 'test' });
-
-      const res = await supertest(app).get(`/snaps/details/${snapName}?channel=`);
-
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ package_name: 'test' });
-    });
-
-    it('handles error responses reasonably', async () => {
+    context('when API returns error response', () => {
       const error = {
         code: 'resource-not-found',
         message: 'Snap has no published revisions in the given context.'
       };
 
-      api = api.reply(404, { error_list: [error] });
+      it('returns status error', async () => {
+        api = api.reply(404, { error_list: [error] });
 
-      const res = await supertest(app).get(`/snaps/details/${snapName}`);
+        const res = await supertest(app).get(`/snaps/details/${snapName}`);
 
-      expect(res.status).toBe(404);
-      expect(res.body).toEqual({ error_list: [error] });
+        expect(res.body).toInclude({ status: 'error' });
+      });
+
+      it('handles error responses reasonably', async () => {
+        api = api.reply(404, { error_list: [error] });
+
+        const res = await supertest(app).get(`/snaps/details/${snapName}`);
+
+        expect(res.status).toBe(404);
+        expect(res.body).toInclude({ error_list: [error] });
+      });
     });
   });
 

--- a/test/unit/src/common/actions/t_snaps.js
+++ b/test/unit/src/common/actions/t_snaps.js
@@ -1,6 +1,7 @@
 import expect from 'expect';
 
 import {
+  fetchSnapStableRelease,
   fetchUserSnaps,
   removeSnap
 } from '../../../../../src/common/actions/snaps';
@@ -39,6 +40,34 @@ describe('repositories actions', () => {
     it('should supply request schema with a body containing the repo URL', () => {
       const repositoryUrl = 'https://github.com/anowner/aname';
       expect(removeSnap(repositoryUrl)[CALL_API].options.body).toInclude(repositoryUrl);
+    });
+  });
+
+  context('fetchSnapStableRelease', () => {
+    const repositoryUrl = 'https://github.com/anowner/aname';
+    const snapName = 'test-snap';
+
+    let action;
+
+    beforeEach(() => {
+      action = fetchSnapStableRelease(repositoryUrl, snapName);
+    });
+
+    it('should supply request, success and failure actions when invoking CALL_API', () => {
+      expect(action[CALL_API].types).toEqual([
+        ActionTypes.FETCH_SNAP_DETAILS,
+        ActionTypes.FETCH_SNAP_DETAILS_SUCCESS,
+        ActionTypes.FETCH_SNAP_DETAILS_ERROR
+      ]);
+    });
+
+    it('should supply a payload with the repository url for given snap', () => {
+      expect(action.payload.id).toEqual(repositoryUrl);
+    });
+
+    it('should request snap details for given snap and stable channel', () => {
+      expect(action[CALL_API].path).toInclude(snapName);
+      expect(action[CALL_API].path).toInclude('channel=stable');
     });
   });
 });

--- a/test/unit/src/common/containers/t_builds.js
+++ b/test/unit/src/common/containers/t_builds.js
@@ -20,7 +20,8 @@ describe('The Builds container', function() {
     },
     snapBuilds: {
       builds: []
-    }
+    },
+    fetchSnapStableRelease: () => {}
   };
 
   it('omits link to "My repos" if not signed in', function() {

--- a/test/unit/src/common/reducers/entities/t_snap.js
+++ b/test/unit/src/common/reducers/entities/t_snap.js
@@ -1,7 +1,8 @@
 import expect from 'expect';
 
 import * as RegisterNameActionTypes from '../../../../../../src/common/actions/register-name';
-import snap from '../../../../../../src/common/reducers/entities/snap.js';
+import snap from '../../../../../../src/common/reducers/entities/snap';
+import { FETCH_SNAP_DETAILS_SUCCESS, FETCH_SNAP_DETAILS_ERROR } from '../../../../../../src/common/actions/snaps';
 
 describe('snaps entities', function() {
 
@@ -80,6 +81,34 @@ describe('snaps entities', function() {
 
       expect(snap(state, action).registerNameStatus).toEqual({
         ...initialStatus
+      });
+    });
+  });
+
+  context('on snap details actions', () => {
+    const id = 'http://github.com/dummy/repo';
+
+    it('should set stable revision to true on FETCH_SNAP_DETAILS_SUCCESS', () => {
+      const action = {
+        type: FETCH_SNAP_DETAILS_SUCCESS,
+        payload: { id, response: { status: 'success' } }
+      };
+
+      expect(snap(state, action)).toEqual({
+        ...state,
+        stableRevision: true
+      });
+    });
+
+    it('should set stable revision to false on FETCH_SNAP_DETAILS_ERROR', () => {
+      const action = {
+        type: FETCH_SNAP_DETAILS_ERROR,
+        payload: { id, response: { status: 'error' } }
+      };
+
+      expect(snap(state, action)).toEqual({
+        ...state,
+        stableRevision: false
       });
     });
   });


### PR DESCRIPTION
Fixes #655

Currently only Twitter sharing is implemented. Others to be defined and implemented in #814.

<img width="1049" alt="screen shot 2017-05-30 at 09 36 59" src="https://cloud.githubusercontent.com/assets/83575/26572816/9eaa9db6-451b-11e7-8a92-bd6611994f81.png">

<img width="1045" alt="screen shot 2017-05-30 at 09 36 31" src="https://cloud.githubusercontent.com/assets/83575/26572817/9eaf35f6-451b-11e7-8244-e8da7030a0ee.png">

### QA

1. Build a snap and wait for it to publish in the store
2. You should see 'No stable version yet' on 'My repos' page
3. Use the dashboard.snapcraft.io UI or snapcraft command line to release snap to stable channel
4. You should see 'To install the latest stable version' on 'My repos' page
