### PR TITLE
Making sure Cancel button is always visible on Add repos page

### DIFF
--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -116,7 +116,7 @@ export class SelectRepositoryListComponent extends Component {
           <HeadingThree>
             { selectedRepositories.length } selected
           </HeadingThree>
-          <div className={ styles.buttons }>
+          <div>
             <LinkButton appearance="neutral" to={`/user/${user.login}`}>
               Cancel
             </LinkButton>

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -116,24 +116,19 @@ export class SelectRepositoryListComponent extends Component {
           <HeadingThree>
             { selectedRepositories.length } selected
           </HeadingThree>
-          <div className={ styles['footer-right'] }>
-            <div className={ styles['button-wrapper'] }>
-              { ids && ids.length > 0 &&
-                <LinkButton appearance="neutral" to={`/user/${user.login}`}>
-                  Cancel
-                </LinkButton>
-              }
-            </div>
-            <div className={ styles['button-wrapper'] }>
-              <Button
-                appearance={ 'positive' }
-                disabled={ !selectedRepositories.length || buttonSpinner }
-                onClick={ this.handleAddRepositories.bind(this) }
-                isSpinner={buttonSpinner}
-              >
-                Add
-              </Button>
-            </div>
+          <div className={ styles.buttons }>
+            <LinkButton appearance="neutral" to={`/user/${user.login}`}>
+              Cancel
+            </LinkButton>
+            {' '}
+            <Button
+              appearance={ 'positive' }
+              disabled={ !selectedRepositories.length || buttonSpinner }
+              onClick={ this.handleAddRepositories.bind(this) }
+              isSpinner={buttonSpinner}
+            >
+              Add
+            </Button>
           </div>
         </div>
       </div>
@@ -143,7 +138,7 @@ export class SelectRepositoryListComponent extends Component {
   renderPageLinks(pageLinks) {
     if (pageLinks) {
       return (
-        <div className={ styles['page-links-container'] }>
+        <div className={ styles.pageLinksContainer }>
           <PageLinks { ...pageLinks } onClick={ this.onPageLinkClick.bind(this) } />
         </div>
       );

--- a/src/common/components/select-repository-list/styles.css
+++ b/src/common/components/select-repository-list/styles.css
@@ -1,4 +1,4 @@
-.page-links-container {
+.pageLinksContainer {
   margin: 20px auto;
   display: flex;
   justify-content: center;
@@ -8,12 +8,4 @@
   display: flex;
   justify-content: space-between;
   margin: 60px 0;
-}
-
-.footer-right {
-  display: flex;
-}
-
-.button-wrapper {
-  margin: 0 5px;
 }


### PR DESCRIPTION
Fixes #755 

Even if there is no repos user should be able to cancel 'Add repos' and go back to 'My repos'.

### QA

1. Clean-up or remove app db (or make sure to sign in with fresh user).
2. Sign in and get redirected to 'Add repos' page
3. Cancel button should be visible, click it to get to empty 'My repos' page
