### PR TITLE
Fixed unhandled promise rejection when action had undefined repo url

### DIFF
--- a/src/common/helpers/github-url.js
+++ b/src/common/helpers/github-url.js
@@ -3,6 +3,10 @@ import parseGitHubUrl from 'parse-github-url';
 export const getGitHubRepoUrl = (owner, name) => {
   let repository = !name ? owner : `${owner}/${name}`;
 
+  if (!repository) {
+    return null;
+  }
+
   // if already a valid GH repository
   if (repository.indexOf('https://github.com/') === 0) {
     return repository;

--- a/test/unit/src/common/helpers/t_github-url.js
+++ b/test/unit/src/common/helpers/t_github-url.js
@@ -12,6 +12,14 @@ describe('getGitHubRepoUrl helper', () => {
     expect(getGitHubRepoUrl('foo', 'bar')).toEqual('https://github.com/foo/bar');
   });
 
+  it('should return GH repo url when passed a GH repo url', () => {
+    expect(getGitHubRepoUrl('https://github.com/foo/bar')).toEqual('https://github.com/foo/bar');
+  });
+
+  it('should return null for empty input', () => {
+    expect(getGitHubRepoUrl()).toBe(null);
+  });
+
 });
 
 describe('parseGitHubRepoUrl helper', () => {


### PR DESCRIPTION
Entities reducer uses `getGitHubRepoUrl` to handle legacy actions, but if it's called with an action that doesn't have an `id` in payload it was causing `getGitHubRepoUrl` to throw an error.

This PR fixes the issue by returning early on empty input.