### PR TITLE
Making 'Add repos' list scrollable

### DIFF
--- a/src/common/components/private-repos-info/index.js
+++ b/src/common/components/private-repos-info/index.js
@@ -136,18 +136,18 @@ export default class PrivateReposInfo extends Component {
             top={this.state.popoverOffsetTop}
             onClick={this.onPopoverClick.bind(this)}
           >
-            <ul>
-              <li>
+            <ul className={ styles.infoList }>
+              <li className={ styles.infoListItem }>
                 <p className={styles.infoMsg}>Want to use a <strong>private repo</strong>? We’re working hard on making these buildable. If you like, we can e-mail you when we’re ready.</p>
                 { this.state.subscribeSuccess
                   ? <p className={styles.successMsg}>{ this.state.message }</p>
                   : this.renderSubsribeForm()
                 }
               </li>
-              <li>
+              <li className={ styles.infoListItem }>
                 <p className={styles.infoMsg}>Don’t have <strong>admin permission</strong>? Ask a repo admin to add it instead, and it will show up in your repo list too.</p>
               </li>
-              <li>
+              <li className={ styles.infoListItem }>
                 { this.renderOrgsInfo() }
                 <Anchor
                   appearance='neutral' flavour='smaller'
@@ -164,7 +164,7 @@ export default class PrivateReposInfo extends Component {
                   OK, it’s added
                 </Button>
               </li>
-              <li>
+              <li className={ styles.infoListItem }>
                 <p className={styles.infoMsg}>Using the <strong>wrong GitHub account</strong>? Sign out and try again with the right one.</p>
                 <Anchor appearance='neutral' flavour='smaller' href="https://github.com/logout">Change account…</Anchor>
               </li>

--- a/src/common/components/private-repos-info/private-repos-info.css
+++ b/src/common/components/private-repos-info/private-repos-info.css
@@ -4,7 +4,6 @@ $background-color: #FFF;
 
 .info {
   position: relative;
-  margin-bottom: 24px;
 }
 
 .info ul {

--- a/src/common/components/private-repos-info/private-repos-info.css
+++ b/src/common/components/private-repos-info/private-repos-info.css
@@ -6,16 +6,16 @@ $background-color: #FFF;
   position: relative;
 }
 
-.info ul {
+.infoList {
   list-style: disc;
   padding-left: 20px;
 }
 
-.info ul li {
+.infoListItem {
   margin-bottom: 12px;
 }
 
-.info ul li:last-child {
+.infoListItem:last-child {
   margin-bottom: 0;
 }
 

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -7,7 +7,6 @@ import { fetchUserOrganizations } from '../../actions/organizations';
 import SelectRepositoryList from '../select-repository-list';
 import { HeadingThree } from '../vanilla/heading';
 import FirstTimeHeading from '../first-time-heading';
-import { CardHighlighted } from '../vanilla/card';
 import PrivateReposInfo from '../private-repos-info';
 
 import styles from './select-repositories-page.css';
@@ -32,13 +31,15 @@ class SelectRepositoriesPage extends Component {
     return (
       <div>
         <FirstTimeHeading />
-        <CardHighlighted>
-          <HeadingThree className={ styles.heading }>
-            Choose repos to add
-          </HeadingThree>
-          <PrivateReposInfo user={ this.props.user } onRefreshClick={this.onRefresh.bind(this)}/>
+        <div className={styles.selectRepositoriesBox}>
+          <div className={styles.selectRepositoriesHeading}>
+            <HeadingThree className={ styles.heading }>
+              Add repos
+            </HeadingThree>
+            <PrivateReposInfo user={ this.props.user } onRefreshClick={this.onRefresh.bind(this)}/>
+          </div>
           <SelectRepositoryList/>
-        </CardHighlighted>
+        </div>
       </div>
     );
   }

--- a/src/common/components/select-repositories-page/select-repositories-page.css
+++ b/src/common/components/select-repositories-page/select-repositories-page.css
@@ -1,3 +1,12 @@
 .heading {
   margin-bottom: 12px;
 }
+
+.selectRepositoriesBox {
+  border: 1px solid $mid-grey;
+  border-radius: 2px;
+}
+
+.selectRepositoriesHeading {
+  padding: 1rem;
+}

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -6,7 +6,6 @@ import SelectRepositoryRow from '../select-repository-row';
 import Spinner from '../spinner';
 import PageLinks from '../page-links';
 import Button, { LinkButton } from '../vanilla/button';
-import { HeadingThree } from '../vanilla/heading';
 import {
   fetchUserRepositories,
 } from '../../actions/repositories';
@@ -107,15 +106,19 @@ export class SelectRepositoryListComponent extends Component {
 
     return (
       <div>
-        { isFetching &&
-          <div className={ spinnerStyles }><Spinner /></div>
-        }
-        { renderedRepos }
-        { pagination }
+        <div className={ styles.repoList }>
+          { isFetching &&
+            <div className={ styles.spinnerWrapper }>
+              <div className={ spinnerStyles }><Spinner /></div>
+            </div>
+          }
+          { renderedRepos }
+          { pagination }
+        </div>
         <div className={ styles.footer }>
-          <HeadingThree>
+          <strong>
             { selectedRepositories.length } selected
-          </HeadingThree>
+          </strong>
           <div>
             <LinkButton appearance="neutral" to={`/user/${user.login}`}>
               Cancel
@@ -136,7 +139,9 @@ export class SelectRepositoryListComponent extends Component {
   }
 
   renderPageLinks(pageLinks) {
-    if (pageLinks) {
+    const hasPagination = !!(pageLinks && (pageLinks.first || pageLinks.last));
+
+    if (hasPagination) {
       return (
         <div className={ styles.pageLinksContainer }>
           <PageLinks { ...pageLinks } onClick={ this.onPageLinkClick.bind(this) } />

--- a/src/common/components/select-repository-list/styles.css
+++ b/src/common/components/select-repository-list/styles.css
@@ -5,7 +5,20 @@
 }
 
 .footer {
+  padding: 1rem;
   display: flex;
   justify-content: space-between;
-  margin: 60px 0;
+  align-items: baseline;
+}
+
+.repoList {
+  height: 300px;
+  overflow: auto;
+  padding: 0 10px;
+  border-bottom: 1px solid $mid-grey;
+  border-top: 1px solid $cool-grey;
+}
+
+.spinnerWrapper {
+  margin-top: 140px;
 }

--- a/src/common/components/select-repository-row/selectRepositoryRow.css
+++ b/src/common/components/select-repository-row/selectRepositoryRow.css
@@ -5,7 +5,7 @@ $error-color: $error;
 .repositoryRow {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px dotted $border-color;
   padding: 10px;
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
Part of #349

Updated styles of 'Add repos' box to make it scrollable. Leading us one step closer to desired design for this page.

Visual design it's based on:
https://github.com/canonical-websites/build.snapcraft.io/issues/715#issuecomment-302097730
<img width="1050" alt="screen shot 2017-06-05 at 16 12 04" src="https://cloud.githubusercontent.com/assets/17748020/26203954/14f7fb94-3bd5-11e7-9de6-55b394ea74e1.png">

Notes:
- currently not responsive (only desktop layout)
- 'Add repos' dialog height is static (not adapting to screen height as defined in spec) (#829)

Implemented:

<img width="1050" alt="screen shot 2017-06-05 at 16 12 04" src="https://cloud.githubusercontent.com/assets/83575/26789929/cb4c7b58-4a09-11e7-9d06-e48e6f79c6ec.png">

### QA:

1. run local server
2. sign in and go to 'Add repos'
3. wait for repos to load
4. list of repos should be scrollable and have styles as above