### PR TITLE
Moved private repo info out of popover

### DIFF
--- a/src/common/components/private-repos-info/index.js
+++ b/src/common/components/private-repos-info/index.js
@@ -1,15 +1,11 @@
 import React, { Component, PropTypes } from 'react';
 
-import { conf } from '../../helpers/config';
-const BASE_URL = conf.get('BASE_URL');
-const GITHUB_AUTH_CLIENT_ID = conf.get('GITHUB_AUTH_CLIENT_ID');
-
 import Popover from '../popover';
-import Button, { Anchor } from '../vanilla/button';
 
+import PrivateReposInfo from './private-repos-info';
 import styles from './private-repos-info.css';
 
-export default class PrivateReposInfo extends Component {
+export default class PrivateReposInfoPopover extends Component {
   constructor() {
     super();
 
@@ -17,10 +13,6 @@ export default class PrivateReposInfo extends Component {
       showPopover: false,
       popoverOffsetLeft: 0,
       popoverOffsetTop: 0,
-      subscribeEmail: '',
-      subscribeSuccess: false,
-      subscribeError: false,
-      message: ''
     };
   }
 
@@ -52,75 +44,6 @@ export default class PrivateReposInfo extends Component {
     });
   }
 
-  onEmailChange(event) {
-    const { target } = event;
-
-    this.setState({
-      subscribeEmail: target.value
-    });
-  }
-
-  async onSubscribeSubmit(event) {
-    event.preventDefault();
-
-    try {
-      const response = await fetch(`${BASE_URL}/api/subscribe/private-repos?email=${encodeURIComponent(this.state.subscribeEmail)}`);
-      const json = await response.json();
-
-      this.setState({
-        subscribeSuccess: json.result === 'success',
-        subscribeError: json.result === 'error',
-        message: json.msg
-      });
-    } catch (e) {
-      this.setState({
-        subscribeSuccess: false,
-        subscribeError: true,
-        message: e.message || 'There was unexpected error while subscribing. Please try again later.'
-      });
-    }
-  }
-
-  renderSubsribeForm() {
-    return (
-      <form onSubmit={this.onSubscribeSubmit.bind(this)}>
-        <label className={styles.subscribeEmailLabel} htmlFor="subscribe_email">E-mail address:</label>
-        <input
-          id="subscribe_email"
-          required={true}
-          className={styles.subscribeEmailInput}
-          type="email"
-          onChange={this.onEmailChange.bind(this)}
-          value={this.state.subscribeEmail}
-        />
-        <Button type="submit" appearance='neutral' flavour='smaller'>Keep me posted</Button>
-        { this.state.subscribeError &&
-          // MailChimp errors may contain HTML links in error messages
-          // but we sanitize it on server side, so should be safe to insert
-          <p className={styles.errorMsg} dangerouslySetInnerHTML={{ __html: this.state.message }}></p>
-        }
-      </form>
-    );
-  }
-
-  renderOrgsInfo() {
-    const { orgs } = this.props.user;
-
-    const number = orgs.length;
-    const plural = orgs.length > 1 ? 's' : '';
-    const orgsList = orgs.slice(0, 3).map((org) => org.login).join(', ');
-
-
-    return (
-      <p className={styles.infoMsg}>Missing an <strong>organization</strong>? {' '}
-        { number
-          ? `Snapcraft has access to ${number} organization${plural} you’re a member of (${orgsList}${number > 3 ? '…' : ''}).`
-          : 'Snapcraft doesn’t have access to any organizations you’re a member of. The organization owner needs to grant access.'
-        }
-      </p>
-    );
-  }
-
   onPopoverClick(event) {
     // prevent popover from closing when it's clicked
     event.nativeEvent.stopImmediatePropagation();
@@ -136,39 +59,10 @@ export default class PrivateReposInfo extends Component {
             top={this.state.popoverOffsetTop}
             onClick={this.onPopoverClick.bind(this)}
           >
-            <ul>
-              <li>
-                <p className={styles.infoMsg}>Want to use a <strong>private repo</strong>? We’re working hard on making these buildable. If you like, we can e-mail you when we’re ready.</p>
-                { this.state.subscribeSuccess
-                  ? <p className={styles.successMsg}>{ this.state.message }</p>
-                  : this.renderSubsribeForm()
-                }
-              </li>
-              <li>
-                <p className={styles.infoMsg}>Don’t have <strong>admin permission</strong>? Ask a repo admin to add it instead, and it will show up in your repo list too.</p>
-              </li>
-              <li>
-                { this.renderOrgsInfo() }
-                <Anchor
-                  appearance='neutral' flavour='smaller'
-                  target="blank" rel="noreferrer noopener"
-                  href={`https://github.com/settings/connections/applications/${GITHUB_AUTH_CLIENT_ID}`}
-                >
-                  Review organization access…
-                </Anchor>
-                {' '}
-                <Button
-                  appearance='neutral' flavour='smaller'
-                  onClick={this.onRefreshClick.bind(this)}
-                >
-                  OK, it’s added
-                </Button>
-              </li>
-              <li>
-                <p className={styles.infoMsg}>Using the <strong>wrong GitHub account</strong>? Sign out and try again with the right one.</p>
-                <Anchor appearance='neutral' flavour='smaller' href="https://github.com/logout">Change account…</Anchor>
-              </li>
-            </ul>
+            <PrivateReposInfo
+              user={this.props.user}
+              onRefreshClick={this.props.onRefreshClick}
+            />
           </Popover>
         }
       </div>
@@ -183,7 +77,7 @@ export default class PrivateReposInfo extends Component {
   }
 }
 
-PrivateReposInfo.propTypes = {
+PrivateReposInfoPopover.propTypes = {
   user: PropTypes.shape({
     orgs: PropTypes.array
   }).isRequired,

--- a/src/common/components/private-repos-info/private-repos-info.js
+++ b/src/common/components/private-repos-info/private-repos-info.js
@@ -1,0 +1,143 @@
+import React, { Component, PropTypes } from 'react';
+
+import { conf } from '../../helpers/config';
+const BASE_URL = conf.get('BASE_URL');
+const GITHUB_AUTH_CLIENT_ID = conf.get('GITHUB_AUTH_CLIENT_ID');
+
+import Button, { Anchor } from '../vanilla/button';
+
+import styles from './private-repos-info.css';
+
+export default class PrivateReposInfo extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      subscribeEmail: '',
+      subscribeSuccess: false,
+      subscribeError: false,
+      message: ''
+    };
+  }
+
+  onEmailChange(event) {
+    const { target } = event;
+
+    this.setState({
+      subscribeEmail: target.value
+    });
+  }
+
+  async onSubscribeSubmit(event) {
+    event.preventDefault();
+
+    try {
+      const response = await fetch(`${BASE_URL}/api/subscribe/private-repos?email=${encodeURIComponent(this.state.subscribeEmail)}`);
+      const json = await response.json();
+
+      this.setState({
+        subscribeSuccess: json.result === 'success',
+        subscribeError: json.result === 'error',
+        message: json.msg
+      });
+    } catch (e) {
+      this.setState({
+        subscribeSuccess: false,
+        subscribeError: true,
+        message: e.message || 'There was unexpected error while subscribing. Please try again later.'
+      });
+    }
+  }
+
+  renderSubsribeForm() {
+    return (
+      <form onSubmit={this.onSubscribeSubmit.bind(this)}>
+        <label className={styles.subscribeEmailLabel} htmlFor="subscribe_email">E-mail address:</label>
+        <input
+          id="subscribe_email"
+          required={true}
+          className={styles.subscribeEmailInput}
+          type="email"
+          onChange={this.onEmailChange.bind(this)}
+          value={this.state.subscribeEmail}
+        />
+        <Button type="submit" appearance='neutral' flavour='smaller'>Keep me posted</Button>
+        { this.state.subscribeError &&
+          // MailChimp errors may contain HTML links in error messages
+          // but we sanitize it on server side, so should be safe to insert
+          <p className={styles.errorMsg} dangerouslySetInnerHTML={{ __html: this.state.message }}></p>
+        }
+      </form>
+    );
+  }
+
+  renderOrgsInfo() {
+    const { orgs } = this.props.user;
+
+    const number = orgs.length;
+    const plural = orgs.length > 1 ? 's' : '';
+    const orgsList = orgs.slice(0, 3).map((org) => org.login).join(', ');
+
+
+    return (
+      <p className={styles.infoMsg}>Missing an <strong>organization</strong>? {' '}
+        { number
+          ? `Snapcraft has access to ${number} organization${plural} you’re a member of (${orgsList}${number > 3 ? '…' : ''}).`
+          : 'Snapcraft doesn’t have access to any organizations you’re a member of. The organization owner needs to grant access.'
+        }
+      </p>
+    );
+  }
+
+  render() {
+    return (
+      <ul>
+        <li>
+          <p className={styles.infoMsg}>Want to use a <strong>private repo</strong>? We’re working hard on making these buildable. If you like, we can e-mail you when we’re ready.</p>
+          { this.state.subscribeSuccess
+            ? <p className={styles.successMsg}>{ this.state.message }</p>
+            : this.renderSubsribeForm()
+          }
+        </li>
+        <li>
+          <p className={styles.infoMsg}>Don’t have <strong>admin permission</strong>? Ask a repo admin to add it instead, and it will show up in your repo list too.</p>
+        </li>
+        <li>
+          { this.renderOrgsInfo() }
+          <Anchor
+            appearance='neutral' flavour='smaller'
+            target="blank" rel="noreferrer noopener"
+            href={`https://github.com/settings/connections/applications/${GITHUB_AUTH_CLIENT_ID}`}
+          >
+            Review organization access…
+          </Anchor>
+          {' '}
+          <Button
+            appearance='neutral' flavour='smaller'
+            onClick={this.onRefreshClick.bind(this)}
+          >
+            OK, it’s added
+          </Button>
+        </li>
+        <li>
+          <p className={styles.infoMsg}>Using the <strong>wrong GitHub account</strong>? Sign out and try again with the right one.</p>
+          <Anchor appearance='neutral' flavour='smaller' href="https://github.com/logout">Change account…</Anchor>
+        </li>
+      </ul>
+    );
+  }
+
+  onRefreshClick() {
+    this.setState({
+      showPopover: false
+    });
+    this.props.onRefreshClick();
+  }
+}
+
+PrivateReposInfo.propTypes = {
+  user: PropTypes.shape({
+    orgs: PropTypes.array
+  }).isRequired,
+  onRefreshClick: PropTypes.func
+};

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -8,7 +8,7 @@ import SelectRepositoryList from '../select-repository-list';
 import { HeadingThree } from '../vanilla/heading';
 import FirstTimeHeading from '../first-time-heading';
 import { CardHighlighted } from '../vanilla/card';
-import PrivateReposInfo from '../private-repos-info';
+import PrivateReposInfoPopover from '../private-repos-info';
 
 import styles from './select-repositories-page.css';
 
@@ -36,7 +36,7 @@ class SelectRepositoriesPage extends Component {
           <HeadingThree className={ styles.heading }>
             Choose repos to add
           </HeadingThree>
-          <PrivateReposInfo user={ this.props.user } onRefreshClick={this.onRefresh.bind(this)}/>
+          <PrivateReposInfoPopover user={ this.props.user } onRefreshClick={this.onRefresh.bind(this)}/>
           <SelectRepositoryList/>
         </CardHighlighted>
       </div>


### PR DESCRIPTION
Part of preparations for #715 

This is a refactoring change that takes private repo info contents and moves it out of current popover to separate component, so it can be reused in different context (scrollable area of Add repos) in #715