### PR TITLE
Applying padding to landing and workflow images to fix firefox issues…

### DIFF
--- a/src/common/components/footer/footer.css
+++ b/src/common/components/footer/footer.css
@@ -21,12 +21,11 @@ body {
   box-sizing: border-box;
 
   font-size: 12px;
-  padding: 2em 1em 1.5em;
+  padding: 2rem 0 1.5rem;
 }
 
 .container {
-  width: 1030px;
-  margin: 0 auto;
+  composes: wrapper from '../../containers/container.css';
 }
 
 .container:after {

--- a/src/common/components/header/header.css
+++ b/src/common/components/header/header.css
@@ -7,8 +7,7 @@ $text-color: $cool-grey;
 }
 
 .container {
-  max-width: 1030px;
-  margin: 0 auto;
+  composes: wrapper from '../../containers/container.css';
 }
 
 .container:after {

--- a/src/common/containers/container.css
+++ b/src/common/containers/container.css
@@ -1,14 +1,15 @@
 .wrapper {
   box-sizing: border-box;
-  max-width: 1030px;
+  max-width: 1070px;
   margin: 0 auto;
-  padding: 0;
+  padding: 0 1.25rem;
 }
 
 .container {
   composes: wrapper;
-  padding: 1em 0px;
   margin-bottom: 60px;
+  padding-bottom: 1rem;
+  padding-top: 1rem;
 }
 
 .spinner {

--- a/src/common/containers/landing.css
+++ b/src/common/containers/landing.css
@@ -97,6 +97,10 @@
   text-align: center;
 }
 
+.centeredImage {
+  margin: 0 auto;
+}
+
 .external {
   background: url($icon-link-external) 100% 0 no-repeat;
   background-size: 0.7em;

--- a/src/common/containers/landing.css
+++ b/src/common/containers/landing.css
@@ -18,7 +18,6 @@
 
 .bannerImage img {
   display: block;
-  padding: 0 1.25rem;
   width: 100%;
 }
 
@@ -41,10 +40,6 @@
 .row {
   display: flex;
   justify-content: space-between;
-}
-
-.row .rowImage {
-  padding: 0 1.25rem;
 }
 
 .rowItemGrow {

--- a/src/common/containers/landing.css
+++ b/src/common/containers/landing.css
@@ -18,6 +18,7 @@
 
 .bannerImage img {
   display: block;
+  padding: 0 1.25rem;
   width: 100%;
 }
 
@@ -40,6 +41,10 @@
 .row {
   display: flex;
   justify-content: space-between;
+}
+
+.row .rowImage {
+  padding: 0 1.25rem;
 }
 
 .rowItemGrow {

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -27,7 +27,7 @@ class Landing extends Component {
 
               <ul className={ styles.banner }>
                 <li className={ styles.bannerImage }>
-                  <img src='https://assets.ubuntu.com/v1/ed6d1c5b-build.snapcraft.hero.svg' />
+                  <img src='https://assets.ubuntu.com/v1/ed6d1c5b-build.snapcraft.hero.svg' alt="Snapcraft hero image, push to GitHub, built automatically, release for your users."/>
                 </li>
 
                 <li className={ styles.bannerLabel }>
@@ -102,7 +102,7 @@ class Landing extends Component {
               How Snapcraft fits into your workflow
             </HeadingTwo>
             <div className={ `${styles.row} `}>
-              <img src='https://assets.ubuntu.com/v1/b70a5c55-workflow-illustration.svg' width='100%' />
+              <img className={ `${styles.rowImage} `} src='https://assets.ubuntu.com/v1/b70a5c55-workflow-illustration.svg' width='100%' alt="Snapcraft workflow diagram."/>
             </div>
           </div>
 

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -102,7 +102,7 @@ class Landing extends Component {
               How Snapcraft fits into your workflow
             </HeadingTwo>
             <div className={ `${styles.row} `}>
-              <img src='https://assets.ubuntu.com/v1/b70a5c55-workflow-illustration.svg' width='100%' alt="Snapcraft workflow diagram."/>
+              <img src='https://assets.ubuntu.com/v1/b70a5c55-workflow-illustration.svg' className={ `${styles.centeredImage}`} alt="Snapcraft workflow diagram."/>
             </div>
           </div>
 

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -102,7 +102,7 @@ class Landing extends Component {
               How Snapcraft fits into your workflow
             </HeadingTwo>
             <div className={ `${styles.row} `}>
-              <img className={ `${styles.rowImage} `} src='https://assets.ubuntu.com/v1/b70a5c55-workflow-illustration.svg' width='100%' alt="Snapcraft workflow diagram."/>
+              <img src='https://assets.ubuntu.com/v1/b70a5c55-workflow-illustration.svg' width='100%' alt="Snapcraft workflow diagram."/>
             </div>
           </div>
 


### PR DESCRIPTION
## What's this PR do?

- Resolves issue of diagram images being close to the edge of the browser window on Firefox and others.

## Where should the reviewer start?

Pull down the branch and go through the [README.md](https://github.com/canonical-websites/build.snapcraft.io/blob/master/README.md) to setup a development branch. 

## How should this be manually tested?

Run the site and view changes on the home page at http://localhost:8000, content images should not but up against the browser window at less than ```1030px```

## Any background context you want to provide?

Fixes #795