### PR TITLE
Fixing height issues for the header, BSI should now match snapcraft

### DIFF
--- a/src/common/components/header/header.css
+++ b/src/common/components/header/header.css
@@ -18,8 +18,10 @@ $text-color: $cool-grey;
 }
 
 .logo {
+  align-items: center;
+  display: flex;
   float: left;
-  padding: 11px 0;
+  height: 51px;
 }
 
 .logo:hover {
@@ -42,8 +44,8 @@ $text-color: $cool-grey;
 .navItem {
   box-sizing: border-box;
   display: inline-block;
-  height: 50px;
-  line-height: 50px;
+  height: 51px;
+  line-height: 51px;
   padding: 0 10px;
   color: $text-color;
   font-size: .875em;


### PR DESCRIPTION
## Done

- Amended the CSS to follow the same height styles from snapcraft.io to BSI.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Open firefox and flick between the demo and snapcraft.io website, both headers should now match in height.


## Issue / Card

Fixes #800 
