### PR TITLE
Resolved text issue and spacing issue with landing welcome message

### DIFF
--- a/src/common/containers/landing.css
+++ b/src/common/containers/landing.css
@@ -11,6 +11,10 @@
   margin: 50px 0 0 0;
 }
 
+.bannerMessage {
+  margin-top: 1.25rem;
+}
+
 .bannerImage {
   width: 920px;
   margin-bottom: 1.2em;

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -44,8 +44,8 @@ class Landing extends Component {
               <div className={ styles.bannerButton }>
                 { this.props.auth.authenticated
                   ? (
-                    <div>
-                      Hi { user.name || user.login }, <a href={`/user/${user.login}`}>let’s check out your repos</a>.
+                    <div className={ styles.bannerMessage }>
+                      Hi { user.name || user.login }, <a href={`/user/${user.login}`}>let’s take a look at your repos</a>.
                     </div>
                   )
                   : (


### PR DESCRIPTION
## Done

- Resolved landing message text once logged in via GitHub. Text should now not conflict with Git terminologies
- Added more spacing between the text and other landing options, should improve readability and to find the content.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Login via your GH account, then view the landing page. Next text and more spacing should be present. 


## Issue / Card

Fixes #733 #568 

## Screenshots

![image](https://user-images.githubusercontent.com/1201618/27393199-8db12fac-56a0-11e7-9837-e686b912d493.png)

