### PR TITLE
Updated uuid version to fix issues with enzyme

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1375,7 +1375,7 @@
       "version": "1.0.0"
     },
     "uuid": {
-      "version": "3.1.0"
+      "version": "3.0.1"
     },
     "v8flags": {
       "version": "2.0.11"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1071,7 +1071,12 @@
       "version": "1.2.0"
     },
     "raven": {
-      "version": "0.12.3"
+      "version": "0.12.3",
+      "dependencies": {
+        "uuid": {
+          "version": "3.0.0"
+        }
+      }
     },
     "raw-body": {
       "version": "2.1.7"
@@ -1370,7 +1375,7 @@
       "version": "1.0.0"
     },
     "uuid": {
-      "version": "3.0.0"
+      "version": "3.1.0"
     },
     "v8flags": {
       "version": "2.0.11"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "reselect": "^2.5.4",
     "sanitize-html": "^1.14.1",
     "serve-favicon": "^2.4.0",
-    "uuid": "^3.0.0",
+    "uuid": "^3.0.1",
     "winston": "^2.3.0",
     "winston-daily-rotate-file": "^1.4.2",
     "yargs": "^6.4.0"


### PR DESCRIPTION
## Done

Updated version of `uuid` module to fix issues with enzyme@2.9.0 trying to import `uuid/v4` causing [failing travis build](https://travis-ci.org/canonical-websites/build.snapcraft.io/builds/245705391)

## QA

- Check out this feature branch
- Run `npm install`
- Run `npm test`
- Tests should pass.

Or just wait to see if travis build gets green ;)
