### PR TITLE
Removed the onDocument click events for closing dialog

### DIFF
--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -184,7 +184,7 @@ export class SelectRepositoryListComponent extends Component {
               { selectedRepositories.length } selected
             </strong>
             {' '}
-            (<Button appearance={ 'link' } onClick={this.onHelpClick.bind(this)} aria-label={ this.state.showMissingReposInfo ? 'Click to close the missing / private repos dialog' : 'Click to open the missing / private repos dialog' }>
+            (<Button appearance={ 'link' } onClick={this.onHelpClick.bind(this)}>
               { this.state.showMissingReposInfo ? 'Return to repos list' : 'Anything missing?' }
             </Button>)
           </div>

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -198,7 +198,6 @@ export class SelectRepositoryListComponent extends Component {
               disabled={ !selectedRepositories.length || buttonSpinner }
               onClick={ this.handleAddRepositories.bind(this) }
               isSpinner={buttonSpinner}
-              id={ 'add-repo'}
             >
               Add
             </Button>

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -198,6 +198,7 @@ export class SelectRepositoryListComponent extends Component {
               disabled={ !selectedRepositories.length || buttonSpinner }
               onClick={ this.handleAddRepositories.bind(this) }
               isSpinner={buttonSpinner}
+              id={ 'add-repo'}
             >
               Add
             </Button>

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -42,12 +42,6 @@ export class SelectRepositoryListComponent extends Component {
     this.props.selectedRepositories && this.props.selectedRepositories.map(id => {
       this.props.dispatch(resetRepository(id));
     });
-
-    // bind document click event
-    if (typeof document !== 'undefined') {
-      this.onBoundDocumentClick = this.onDocumentClick.bind(this);
-      document.addEventListener('click', this.onBoundDocumentClick);
-    }
   }
 
   componentWillUnmount() {
@@ -55,12 +49,6 @@ export class SelectRepositoryListComponent extends Component {
     if (typeof document !== 'undefined') {
       document.removeEventListener('click', this.onBoundDocumentClick);
     }
-  }
-
-  onDocumentClick() {
-    this.setState({
-      showMissingReposInfo: false
-    });
   }
 
   onHelpClick(event) {
@@ -196,7 +184,7 @@ export class SelectRepositoryListComponent extends Component {
               { selectedRepositories.length } selected
             </strong>
             {' '}
-            (<a href="#" onClick={this.onHelpClick.bind(this)}>
+            (<a onClick={this.onHelpClick.bind(this)} aria-label={ this.state.showMissingReposInfo ? 'Click to close the missing / private repos dialog' : 'Click to open the missing / private repos dialog' }>
               { this.state.showMissingReposInfo ? 'Return to repos list' : 'Anything missing?' }
             </a>)
           </div>

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -184,9 +184,9 @@ export class SelectRepositoryListComponent extends Component {
               { selectedRepositories.length } selected
             </strong>
             {' '}
-            (<a onClick={this.onHelpClick.bind(this)} aria-label={ this.state.showMissingReposInfo ? 'Click to close the missing / private repos dialog' : 'Click to open the missing / private repos dialog' }>
+            (<Button appearance={ 'link' } onClick={this.onHelpClick.bind(this)} aria-label={ this.state.showMissingReposInfo ? 'Click to close the missing / private repos dialog' : 'Click to open the missing / private repos dialog' }>
               { this.state.showMissingReposInfo ? 'Return to repos list' : 'Anything missing?' }
-            </a>)
+            </Button>)
           </div>
           <div>
             <LinkButton appearance="base" to={`/user/${user.login}`}>

--- a/src/common/components/vanilla/button/button.css
+++ b/src/common/components/vanilla/button/button.css
@@ -16,6 +16,8 @@ $neutral-button-color-hover: rgba(0, 0, 0, 0.1);
 $neutral-button-text-color: $dark-grey;
 $neutral-border-color: $dark-grey;
 
+$link-button-text-color: $link-blue;
+
 .button {
   font-family: $base-font-family;
   font-smoothing: subpixel-antialiased;
@@ -97,6 +99,23 @@ $neutral-border-color: $dark-grey;
 .neutral:focus,
 .neutral:hover {
   background-color: $neutral-button-color-hover;
+}
+
+.link {
+  -webkit-appearance: none;
+  -moz-appearance:    none;
+  appearance:         none;
+  background-color: transparent;
+  border: 0;
+  color: $internal-button-text-color;
+  padding: 0;
+}
+
+.link:active,
+.link:focus,
+.link:hover {
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 .button:disabled {

--- a/src/common/components/vanilla/button/button.css
+++ b/src/common/components/vanilla/button/button.css
@@ -16,7 +16,7 @@ $neutral-button-color-hover: rgba(0, 0, 0, 0.1);
 $neutral-button-text-color: $dark-grey;
 $neutral-border-color: $dark-grey;
 
-$link-button-text-color: $link-blue;
+$internal-button-text-color: $link-blue;
 
 .button {
   font-family: $base-font-family;

--- a/src/common/components/vanilla/button/button.css
+++ b/src/common/components/vanilla/button/button.css
@@ -16,7 +16,7 @@ $neutral-button-color-hover: rgba(0, 0, 0, 0.1);
 $neutral-button-text-color: $dark-grey;
 $neutral-border-color: $dark-grey;
 
-$internal-button-text-color: $link-blue;
+$link-button-text-color: $link-blue;
 
 .button {
   font-family: $base-font-family;
@@ -107,7 +107,7 @@ $internal-button-text-color: $link-blue;
   appearance:         none;
   background-color: transparent;
   border: 0;
-  color: $internal-button-text-color;
+  color: $link-button-text-color;
   padding: 0;
 }
 

--- a/src/common/components/vanilla/button/index.js
+++ b/src/common/components/vanilla/button/index.js
@@ -33,7 +33,7 @@ function createButtonComponent(Component) {
     disabled: PropTypes.bool,
     children: PropTypes.string,
     onClick: PropTypes.func,
-    appearance: React.PropTypes.oneOf(['positive', 'negative', 'neutral', 'base']),
+    appearance: React.PropTypes.oneOf(['positive', 'negative', 'neutral', 'base', 'link']),
     flavour: React.PropTypes.oneOf(['normal','bigger', 'smaller']),
     href: PropTypes.string,
     icon: PropTypes.string

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -92,7 +92,7 @@ describe('<SelectRepositoryListComponent /> instance', function() {
     });
 
     it('should render disabled Add button', function() {
-      expect(wrapper.find('Button').prop('disabled')).toBe(true);
+      expect(wrapper.find('#add-repo').prop('disabled')).toBe(true);
     });
 
     it('should show message about 0 selected repos', function() {
@@ -224,7 +224,7 @@ describe('<SelectRepositoryListComponent /> instance', function() {
     });
 
     it('should dispatch selected repositories for building on add button click', function() {
-      wrapper.find(Button).simulate('click');
+      wrapper.find('#add-repo').simulate('click');
       expect(spy).toHaveBeenCalledWith(addRepos(testProps.reposToAdd));
     });
   });

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -92,7 +92,7 @@ describe('<SelectRepositoryListComponent /> instance', function() {
     });
 
     it('should render disabled Add button', function() {
-      expect(wrapper.find('#add-repo').prop('disabled')).toBe(true);
+      expect(wrapper.find('Button').last().prop('disabled')).toBe(true);
     });
 
     it('should show message about 0 selected repos', function() {
@@ -224,7 +224,7 @@ describe('<SelectRepositoryListComponent /> instance', function() {
     });
 
     it('should dispatch selected repositories for building on add button click', function() {
-      wrapper.find('#add-repo').simulate('click');
+      wrapper.find('Button').last().simulate('click');
       expect(spy).toHaveBeenCalledWith(addRepos(testProps.reposToAdd));
     });
   });

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -11,7 +11,7 @@ import {
   resetRepository,
   toggleRepositorySelection,
 } from '../../../../../../src/common/actions/repository';
-import Button, { LinkButton } from '../../../../../../src/common/components/vanilla/button';
+import { LinkButton } from '../../../../../../src/common/components/vanilla/button';
 import Spinner from '../../../../../../src/common/components/spinner';
 
 describe('<SelectRepositoryListComponent /> instance', function() {


### PR DESCRIPTION
Removed the onDocument click events for closing the missing / private repo dialog. Updated toggle link with aria details to help accessibility.

## Done

- Removed JS from ```select-repository-list/index.js``` file to stop clicking outside of dialog
- Updated markup on the renders on help link, including:
- - Aria labels to update what action is being taken on click
- - Removed anchor tags on the help link, this should be a button as anchor tags need to link to a new page or ID on the page and effect the URL.
- - Created link button style to look similar to an anchor link


## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to the add repos page, click the help link and try to click outside the add repos dialog. The popup should now stay active. Also clicking on the help link shouldn't jump a user to the top of the page now.


## Issue / Card

- Fixes #854 #853  

