### PR TITLE
Add repos spinner delayed by 2 seconds

### DIFF
--- a/src/common/actions/repositories.js
+++ b/src/common/actions/repositories.js
@@ -4,6 +4,7 @@ import { fetchUserSnaps } from './snaps.js';
 export const REPOSITORIES_REQUEST = 'REPOSITORIES_REQUEST';
 export const REPOSITORIES_SUCCESS = 'REPOSITORIES_SUCCESS';
 export const REPOSITORIES_FAILURE = 'REPOSITORIES_FAILURE';
+export const REPOSITORIES_DELAYED = 'REPOSITORIES_DELAYED';
 
 export function fetchUserRepositories(pageNumber) {
   let path = '/api/github/repos';
@@ -14,7 +15,7 @@ export function fetchUserRepositories(pageNumber) {
 
   return {
     [CALL_API]: {
-      types: [REPOSITORIES_REQUEST, REPOSITORIES_SUCCESS, REPOSITORIES_FAILURE],
+      types: [REPOSITORIES_REQUEST, REPOSITORIES_SUCCESS, REPOSITORIES_FAILURE, REPOSITORIES_DELAYED],
       path: path,
       options: {
         headers: { 'Content-Type': 'application/json' },

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -34,7 +34,8 @@ export class SelectRepositoryListComponent extends Component {
     super();
 
     this.state = {
-      showMissingReposInfo: false
+      showMissingReposInfo: false,
+      addTriggered: false,
     };
   }
 
@@ -108,8 +109,10 @@ export class SelectRepositoryListComponent extends Component {
   handleAddRepositories() {
     const { reposToAdd, user } = this.props;
 
-    // TODO else "You have not selected any repositories"
     if (reposToAdd.length) {
+      this.setState({
+        addTriggered: true,
+      });
       this.props.dispatch(addRepos(reposToAdd, user.login));
     }
   }
@@ -137,12 +140,14 @@ export class SelectRepositoryListComponent extends Component {
   }
 
   renderRepoList() {
-    const { ids, error, isFetching, pageLinks } = this.props.repositories;
+    const { ids, error, isFetching, isDelayed, pageLinks } = this.props.repositories;
 
     if (isFetching) {
       return (
         <div className={ styles.spinnerWrapper }>
-          <div className={ spinnerStyles }><Spinner /></div>
+          { isDelayed &&
+            <div className={ spinnerStyles }><Spinner /></div>
+          }
         </div>
       );
     }
@@ -169,9 +174,8 @@ export class SelectRepositoryListComponent extends Component {
 
   render() {
     const { user, selectedRepositories, isAddingSnaps, isUpdatingSnaps } = this.props;
-    const { isFetching } = this.props.repositories;
 
-    const buttonSpinner = isFetching || isAddingSnaps || isUpdatingSnaps;
+    const buttonSpinner = this.state.addTriggered && (isAddingSnaps || isUpdatingSnaps);
 
     return (
       <div>

--- a/src/common/reducers/repositories.js
+++ b/src/common/reducers/repositories.js
@@ -4,6 +4,7 @@ import * as ActionTypes from '../actions/repositories';
 
 export function repositories(state = {
   isFetching: false,
+  isDelayed: false,
   error: null,
   ids: [],
   pageLinks: {}
@@ -19,6 +20,7 @@ export function repositories(state = {
       return {
         ...state,
         isFetching: false,
+        isDelayed: false,
         error: null,
         ids: union(state.ids, action.payload.response.result),
         pageLinks: action.payload.response.pageLinks
@@ -27,7 +29,13 @@ export function repositories(state = {
       return {
         ...state,
         isFetching: false,
+        isDelayed: false,
         error: action.payload.error,
+      };
+    case ActionTypes.REPOSITORIES_DELAYED:
+      return {
+        ...state,
+        isDelayed: true
       };
     default:
       return state;

--- a/test/unit/src/common/actions/t_repositories.js
+++ b/test/unit/src/common/actions/t_repositories.js
@@ -19,7 +19,8 @@ describe('repositories actions', () => {
         expect(fetchUserRepositories(pageNumber)[CALL_API].types).toEqual([
           ActionTypes.REPOSITORIES_REQUEST,
           ActionTypes.REPOSITORIES_SUCCESS,
-          ActionTypes.REPOSITORIES_FAILURE
+          ActionTypes.REPOSITORIES_FAILURE,
+          ActionTypes.REPOSITORIES_DELAYED
         ]);
       });
     });

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -79,12 +79,6 @@ describe('<SelectRepositoryListComponent /> instance', function() {
       spy.restore();
     });
 
-    it('should show spinner when repositories are being fetched', function() {
-      expect(wrapper.find(Spinner).length).toBe(0);
-      wrapper.setProps({ repositories: Object.assign({}, props.repositories, { isFetching: true }) });
-      expect(wrapper.find(Spinner).length).toBe(1);
-    });
-
     it('should hide LinkButton when has no repositories', function() {
       expect(wrapper.find(LinkButton).length).toBe(1);
       wrapper.setProps({ repositories: Object.assign({}, props.repositories, { ids: [] }) });

--- a/test/unit/src/common/reducers/t_repositories.js
+++ b/test/unit/src/common/reducers/t_repositories.js
@@ -7,6 +7,7 @@ import * as ActionTypes from '../../../../../src/common/actions/repositories';
 describe('repositories reducers', () => {
   const initialState = {
     isFetching: false,
+    isDelayed: false,
     pageLinks: {},
     error: null,
     ids: []
@@ -36,6 +37,7 @@ describe('repositories reducers', () => {
     const state = {
       ...initialState,
       isFetching: true,
+      isDelayed: true,
       error: 'Previous error'
     };
 
@@ -55,13 +57,18 @@ describe('repositories reducers', () => {
     it('should clean error', () => {
       expect(repositories(state, action).error).toBe(null);
     });
+
+    it('should clear delayed flag', () => {
+      expect(repositories(state, action).isDelayed).toBe(false);
+    });
   });
 
   context('REPOSITORIES_FAILURE', () => {
     const state = {
       ...initialState,
       ids,
-      isFetching: true
+      isFetching: true,
+      isDelayed: true
     };
 
     const action = {
@@ -72,11 +79,32 @@ describe('repositories reducers', () => {
       error: true
     };
 
-    it('should handle fetch failure', () => {
+    it('should stop fetching', () => {
+      expect(repositories(state, action).isFetching).toBe(false);
+    });
+
+    it('should set error', () => {
+      expect(repositories(state, action).error).toBe(action.payload.error);
+    });
+
+    it('should clear isDelayed flag', () => {
+      expect(repositories(state, action).isDelayed).toBe(false);
+    });
+  });
+
+  context('REPOSITORIES_DELAYED', () => {
+    const state = {
+      ...initialState
+    };
+
+    const action = {
+      type: ActionTypes.REPOSITORIES_DELAYED
+    };
+
+    it('should handle delayed response', () => {
       expect(repositories(state, action)).toEqual({
         ...state,
-        isFetching: false,
-        error: action.payload.error
+        isDelayed: true
       });
     });
   });


### PR DESCRIPTION
## Done

Updated "Add repos" to show spinner only if repos are not returned by API in 2 seconds.

Also 

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Set up a proxy or browser to fake a slow connection
- Go to "Add repos" page
- Should appear as empty list at first
- If repos are returned in less then 2 seconds they should appear (no spinner should be shown)
- If repos take more then 2 seconds spinner show show in the middle of Add repos dialog


## Issue / Card

Fixes #661
Fixes #855
