### PR TITLE
832 add repos amount number

### DIFF
--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -129,9 +129,6 @@ export class SelectRepositoryListComponent extends Component {
     const { ids, error, isFetching, isDelayed } = this.props.repositories;
     const { selectedRepositories } = this.props;
 
-    let repoAmount = ids;
-    let selectedRepos = selectedRepositories;
-
     if (isFetching && ids.length === 0) {
       return (
         <span>Calculating your total repositories&hellip;</span>
@@ -141,13 +138,12 @@ export class SelectRepositoryListComponent extends Component {
     return (
       <div>
           <strong>
-            { selectedRepos.length } selected out of
+            { selectedRepositories.length } selected out of
           </strong>
           {' '}
           <span>
-            { repoAmount.length } Total repositories
+            { ids.length } Total repositories
           </span>
-          {' '}
       </div>
     );
   }

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -126,7 +126,7 @@ export class SelectRepositoryListComponent extends Component {
   }
 
   renderRepoAmount() {
-    const { ids, error, isFetching, isDelayed } = this.props.repositories;
+    const { ids, isFetching } = this.props.repositories;
     const { selectedRepositories } = this.props;
 
     if (isFetching && ids.length === 0) {
@@ -137,9 +137,9 @@ export class SelectRepositoryListComponent extends Component {
 
     return (
       <div>
-          <strong>
-            { selectedRepositories.length } selected out of { ids.length } Total repositories
-          </strong>
+        <strong>
+          { selectedRepositories.length } selected out of { ids.length } Total repositories
+        </strong>
       </div>
     );
   }

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -138,12 +138,8 @@ export class SelectRepositoryListComponent extends Component {
     return (
       <div>
           <strong>
-            { selectedRepositories.length } selected out of
+            { selectedRepositories.length } selected out of { ids.length } Total repositories
           </strong>
-          {' '}
-          <span>
-            { ids.length } Total repositories
-          </span>
       </div>
     );
   }

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -125,6 +125,33 @@ export class SelectRepositoryListComponent extends Component {
     return renderedRepos;
   }
 
+  renderRepoAmount() {
+    const { ids, error, isFetching, isDelayed } = this.props.repositories;
+    const { selectedRepositories } = this.props;
+
+    let repoAmount = ids;
+    let selectedRepos = selectedRepositories;
+
+    if (isFetching && ids.length === 0) {
+      return (
+        <span>Calculating your total repositories&hellip;</span>
+      );
+    }
+
+    return (
+      <div>
+          <strong>
+            { selectedRepos.length } selected out of
+          </strong>
+          {' '}
+          <span>
+            { repoAmount.length } Total repositories
+          </span>
+          {' '}
+      </div>
+    );
+  }
+
   render() {
     const { user, selectedRepositories, isAddingSnaps, isUpdatingSnaps } = this.props;
 
@@ -149,13 +176,13 @@ export class SelectRepositoryListComponent extends Component {
             <div className={ styles.arrow } />
           }
           <div className={ styles.summary }>
-            <strong>
-              { selectedRepositories.length } selected
-            </strong>
-            {' '}
-            (<Button appearance={ 'link' } onClick={this.onHelpClick.bind(this)}>
-              { this.state.showMissingReposInfo ? 'Return to repos list' : 'Anything missing?' }
-            </Button>)
+            { this.renderRepoAmount() }
+            <div>
+              {'\u00A0'}
+              (<Button appearance={ 'link' } onClick={this.onHelpClick.bind(this)}>
+                { this.state.showMissingReposInfo ? 'Return to repos list' : 'Anything missing?' }
+              </Button>)
+            </div>
           </div>
           <div>
             <LinkButton appearance="base" to={`/user/${user.login}`}>

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -129,24 +129,15 @@ export class SelectRepositoryListComponent extends Component {
     const { ids, isFetching } = this.props.repositories;
     const { selectedRepositories } = this.props;
 
-    let reposSelected = false;
-
     // Return nothing until isFetching completes
     if (isFetching || ids.length === 0) {
       return;
     }
 
-    // Check if any respos have been selected
-    if (selectedRepositories.length > 0) {
-      reposSelected = true;
-    } else {
-      reposSelected = false;
-    }
-
     // Return selected repos amount and the total
     return (
       <strong>
-        { reposSelected &&
+        { (selectedRepositories.length > 0) &&
           <span>{ selectedRepositories.length } selected of </span>
         }{ ids.length } repos
       </strong>

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -129,10 +129,12 @@ export class SelectRepositoryListComponent extends Component {
     const { ids, isFetching } = this.props.repositories;
     const { selectedRepositories } = this.props;
 
-    if (isFetching && ids.length === 0) {
+    // Return nothing until isFetching completes
+    if (isFetching) {
       return;
     }
 
+    // Return selected repos amount and the total
     return (
       <strong>
         { selectedRepositories.length } selected of { ids.length } repos
@@ -165,12 +167,10 @@ export class SelectRepositoryListComponent extends Component {
           }
           <div className={ styles.summary }>
             { this.renderRepoAmount() }
-            <div>
-              {'\u00A0'}
-              (<Button appearance={ 'link' } onClick={this.onHelpClick.bind(this)}>
-                { this.state.showMissingReposInfo ? 'Return to repos list' : 'Anything missing?' }
-              </Button>)
-            </div>
+            {'\u00A0'}
+            (<Button appearance={ 'link' } onClick={this.onHelpClick.bind(this)}>
+              { this.state.showMissingReposInfo ? 'Return to repos list' : 'Anything missing?' }
+            </Button>)
           </div>
           <div>
             <LinkButton appearance="base" to={`/user/${user.login}`}>

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -139,7 +139,8 @@ export class SelectRepositoryListComponent extends Component {
       <strong>
         { (selectedRepositories.length > 0) &&
           <span>{ selectedRepositories.length } selected of </span>
-        }{ ids.length } repos
+        }
+        { ids.length } repos
       </strong>
     );
   }

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -130,9 +130,7 @@ export class SelectRepositoryListComponent extends Component {
     const { selectedRepositories } = this.props;
 
     if (isFetching && ids.length === 0) {
-      return (
-        <span>Calculating your total repositories&hellip;</span>
-      );
+      return;
     }
 
     return (

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -138,7 +138,7 @@ export class SelectRepositoryListComponent extends Component {
     return (
       <div>
         <strong>
-          { selectedRepositories.length } selected out of { ids.length } Total repositories
+          { selectedRepositories.length } selected out of { ids.length } repositories
         </strong>
       </div>
     );

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -136,11 +136,9 @@ export class SelectRepositoryListComponent extends Component {
     }
 
     return (
-      <div>
-        <strong>
-          { selectedRepositories.length } selected out of { ids.length } repositories
-        </strong>
-      </div>
+      <strong>
+        { selectedRepositories.length } selected of { ids.length } repos
+      </strong>
     );
   }
 

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -129,15 +129,26 @@ export class SelectRepositoryListComponent extends Component {
     const { ids, isFetching } = this.props.repositories;
     const { selectedRepositories } = this.props;
 
+    let reposSelected = false;
+
     // Return nothing until isFetching completes
-    if (isFetching) {
+    if (isFetching || ids.length === 0) {
       return;
+    }
+
+    // Check if any respos have been selected
+    if (selectedRepositories.length > 0) {
+      reposSelected = true;
+    } else {
+      reposSelected = false;
     }
 
     // Return selected repos amount and the total
     return (
       <strong>
-        { selectedRepositories.length } selected of { ids.length } repos
+        { reposSelected &&
+          <span>{ selectedRepositories.length } selected of </span>
+        }{ ids.length } repos
       </strong>
     );
   }

--- a/src/common/components/select-repository-list/styles.css
+++ b/src/common/components/select-repository-list/styles.css
@@ -7,6 +7,9 @@
 }
 
 .summary {
+  flex-direction: row;
+  justify-content: flex-end;
+  display: flex;
   flex: 1;
   margin-right: 10px;
   text-align: right;

--- a/src/common/components/select-repository-list/styles.css
+++ b/src/common/components/select-repository-list/styles.css
@@ -7,11 +7,9 @@
 }
 
 .summary {
-  display: flex;
   flex: 1;
   margin-right: 10px;
   text-align: right;
-  justify-content: flex-end;
 }
 
 .repoList {

--- a/src/common/components/select-repository-list/styles.css
+++ b/src/common/components/select-repository-list/styles.css
@@ -7,8 +7,6 @@
 }
 
 .summary {
-  flex-direction: row;
-  justify-content: flex-end;
   display: flex;
   flex: 1;
   margin-right: 10px;

--- a/src/common/components/select-repository-list/styles.css
+++ b/src/common/components/select-repository-list/styles.css
@@ -11,6 +11,7 @@
   flex: 1;
   margin-right: 10px;
   text-align: right;
+  justify-content: flex-end;
 }
 
 .repoList {

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -90,11 +90,11 @@ describe('<SelectRepositoryListComponent /> instance', function() {
     });
 
     it('should show message about 0 selected repos', function() {
-      expect(wrapper.html()).toInclude('0 selected out of');
+      expect(wrapper.html()).toInclude('0 selected of');
     });
 
     it('should show message about 3 total repos', function() {
-      expect(wrapper.html()).toInclude('3 repositories');
+      expect(wrapper.html()).toInclude('3 repos');
     });
 
     it('should render same number of rows as repos in state', function() {

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -90,7 +90,11 @@ describe('<SelectRepositoryListComponent /> instance', function() {
     });
 
     it('should show message about 0 selected repos', function() {
-      expect(wrapper.html()).toInclude('0 selected');
+      expect(wrapper.html()).toInclude('0 selected out of');
+    });
+
+    it('should show message about 3 total repos', function() {
+      expect(wrapper.html()).toInclude('3 Total repositories');
     });
 
     it('should render same number of rows as repos in state', function() {

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -94,7 +94,7 @@ describe('<SelectRepositoryListComponent /> instance', function() {
     });
 
     it('should show message about 3 total repos', function() {
-      expect(wrapper.html()).toInclude('3 Total repositories');
+      expect(wrapper.html()).toInclude('3 repositories');
     });
 
     it('should render same number of rows as repos in state', function() {

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -89,12 +89,12 @@ describe('<SelectRepositoryListComponent /> instance', function() {
       expect(wrapper.find('Button').last().prop('disabled')).toBe(true);
     });
 
-    it('should show message about 0 selected repos', function() {
-      expect(wrapper.html()).toInclude('0 selected of');
-    });
-
     it('should show message about 3 total repos', function() {
       expect(wrapper.html()).toInclude('3 repos');
+    });
+
+    it('should show not message about 0 selected repos', function() {
+      expect(wrapper.html()).toNotInclude('0 selected of');
     });
 
     it('should render same number of rows as repos in state', function() {
@@ -157,6 +157,10 @@ describe('<SelectRepositoryListComponent /> instance', function() {
     it('should dispatch reset action on all selected repos on mount', function() {
       wrapper.instance().componentDidMount();
       expect(spy).toHaveBeenCalledWith(resetRepository(repoId));
+    });
+
+    it('should show message about 1 selected repos', function() {
+      expect(wrapper.html()).toInclude('1 selected of');
     });
   });
 


### PR DESCRIPTION
## Done

- Matches design and placement of the selected and total repos message on the add repos listing page
- Creates new function to pull in the amount of repos and what is selected with unit tests

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to the add repos page once logged in. When loading a message should show calculating your repos. Once complete the selected and total message should be present. 


## Issue / Card

Fixes #832 
