### PR TITLE
Set up building Vanilla CSS modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "npm run migrate:latest && node ./webpack/webpack-dev-server",
     "start-build": "node dist/server/",
     "build": "./scripts/build.sh",
+    "build:vanilla-modules": "node-sass --include-path ./node_modules -o ./src/common/style/vanilla/css ./src/common/style/vanilla/",
     "lint": "eslint -c .eslintrc.js '**/*.js'",
     "test": "npm run test:setup-db && nyc npm run test:unit && npm run test:routes && npm run lint",
     "test:setup-db": "rm -f test.sqlite3 && NODE_ENV=test npm run migrate:latest",
@@ -113,6 +114,7 @@
     "flux-standard-action": "^1.0.0",
     "mocha": "^3.1.2",
     "nock": "^9.0.2",
+    "node-sass": "^4.5.3",
     "nyc": "^9.0.1",
     "postcss-loader": "^1.0.0",
     "postcss-simple-vars": "^3.0.0",
@@ -128,6 +130,7 @@
     "style-loader": "^0.13.1",
     "supertest": "^2.0.0",
     "url-loader": "^0.5.7",
+    "vanilla-framework": "git+https://git@github.com/vanilla-framework/vanilla-framework.git#e3b7034a1caf39e4ed87b9481d5fe0e9913c2b0f",
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.8.4",
     "webpack-hot-middleware": "^2.13.0"

--- a/src/common/style/vanilla/breadcrumbs.scss
+++ b/src/common/style/vanilla/breadcrumbs.scss
@@ -1,0 +1,3 @@
+@import 'vanilla-framework/scss/patterns_breadcrumbs.scss';
+
+@include vf-p-breadcrumbs;

--- a/src/common/style/vanilla/button.scss
+++ b/src/common/style/vanilla/button.scss
@@ -1,0 +1,4 @@
+@import 'vanilla-framework/scss/base_button.scss';
+@import 'vanilla-framework/scss/patterns_buttons.scss';
+
+@include vf-p-buttons;

--- a/src/common/style/vanilla/css/breadcrumbs.css
+++ b/src/common/style/vanilla/css/breadcrumbs.css
@@ -1,0 +1,25 @@
+.p-breadcrumbs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%; }
+  .p-breadcrumbs__item {
+    display: inline-block;
+    margin: 0 0.75rem 0.25rem 0.25rem;
+    position: relative; }
+    .p-breadcrumbs__item:not(:first-of-type) {
+      margin-right: -.25rem;
+      text-indent: 1rem; }
+    .p-breadcrumbs__item:first-of-type {
+      margin-right: -.25rem; }
+    .p-breadcrumbs__item:not(:first-of-type)::before {
+      content: '\203A';
+      left: -.75rem;
+      position: absolute;
+      top: 0; }
+  .p-breadcrumbs__link {
+    color: #111;
+    font-weight: 400;
+    text-decoration: none; }
+    .p-breadcrumbs__link:hover {
+      color: #007aa6; }

--- a/src/common/style/vanilla/css/button.css
+++ b/src/common/style/vanilla/css/button.css
@@ -1,0 +1,254 @@
+.p-button {
+  transition-duration: 0.165s;
+  transition-property: background-color;
+  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  background-color: #fff;
+  border-color: #cdcdcd;
+  border-radius: .125rem;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  color: #111;
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 1rem;
+  font-smoothing: subpixel-antialiased;
+  font-weight: 300;
+  line-height: 1rem;
+  outline: none;
+  padding: 0.75rem 1.5rem;
+  text-align: center;
+  text-decoration: none;
+  width: 100%; }
+  @media only screen and (min-width: 768px) {
+    .p-button {
+      width: auto; } }
+  .p-button:visited {
+    color: #111; }
+  .p-button:active, .p-button:focus, .p-button:hover {
+    background-color: #f7f7f7;
+    border-color: #cdcdcd;
+    text-decoration: none; }
+  .p-button:disabled, .p-button.is--disabled {
+    cursor: not-allowed;
+    opacity: .5; }
+    .p-button:disabled:active, .p-button:disabled:focus, .p-button:disabled:hover, .p-button.is--disabled:active, .p-button.is--disabled:focus, .p-button.is--disabled:hover {
+      background-color: #fff;
+      border-color: #fff; }
+  .p-button .p-link--external {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+
+.p-button--neutral {
+  transition-duration: 0.165s;
+  transition-property: background-color;
+  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  background-color: #fff;
+  border-color: #cdcdcd;
+  border-radius: .125rem;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  color: #111;
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 1rem;
+  font-smoothing: subpixel-antialiased;
+  font-weight: 300;
+  line-height: 1rem;
+  outline: none;
+  padding: 0.75rem 1.5rem;
+  text-align: center;
+  text-decoration: none;
+  width: 100%; }
+  @media only screen and (min-width: 768px) {
+    .p-button--neutral {
+      width: auto; } }
+  .p-button--neutral:visited {
+    color: #111; }
+  .p-button--neutral:active, .p-button--neutral:focus, .p-button--neutral:hover {
+    background-color: #f7f7f7;
+    border-color: #cdcdcd;
+    text-decoration: none; }
+  .p-button--neutral:disabled, .p-button--neutral.is--disabled {
+    cursor: not-allowed;
+    opacity: .5; }
+    .p-button--neutral:disabled:active, .p-button--neutral:disabled:focus, .p-button--neutral:disabled:hover, .p-button--neutral.is--disabled:active, .p-button--neutral.is--disabled:focus, .p-button--neutral.is--disabled:hover {
+      background-color: transparent;
+      border-color: #cdcdcd; }
+  .p-button--neutral .p-link--external {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+
+.p-button--brand {
+  transition-duration: 0.165s;
+  transition-property: background-color;
+  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  background-color: #333;
+  border-color: #333;
+  border-radius: .125rem;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  color: #fff;
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 1rem;
+  font-smoothing: subpixel-antialiased;
+  font-weight: 300;
+  line-height: 1rem;
+  outline: none;
+  padding: 0.75rem 1.5rem;
+  text-align: center;
+  text-decoration: none;
+  width: 100%; }
+  @media only screen and (min-width: 768px) {
+    .p-button--brand {
+      width: auto; } }
+  .p-button--brand:visited {
+    color: #fff; }
+  .p-button--brand:active, .p-button--brand:focus, .p-button--brand:hover {
+    background-color: #1a1a1a;
+    border-color: #1a1a1a;
+    text-decoration: none; }
+  .p-button--brand:disabled, .p-button--brand.is--disabled {
+    cursor: not-allowed;
+    opacity: .5; }
+    .p-button--brand:disabled:active, .p-button--brand:disabled:focus, .p-button--brand:disabled:hover, .p-button--brand.is--disabled:active, .p-button--brand.is--disabled:focus, .p-button--brand.is--disabled:hover {
+      background-color: #333;
+      border-color: #333; }
+  .p-button--brand .p-link--external {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23fff' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+
+.p-button--positive {
+  transition-duration: 0.165s;
+  transition-property: background-color;
+  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  background-color: #0e8420;
+  border-color: #0e8420;
+  border-radius: .125rem;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  color: #fff;
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 1rem;
+  font-smoothing: subpixel-antialiased;
+  font-weight: 300;
+  line-height: 1rem;
+  outline: none;
+  padding: 0.75rem 1.5rem;
+  text-align: center;
+  text-decoration: none;
+  width: 100%; }
+  @media only screen and (min-width: 768px) {
+    .p-button--positive {
+      width: auto; } }
+  .p-button--positive:visited {
+    color: #fff; }
+  .p-button--positive:active, .p-button--positive:focus, .p-button--positive:hover {
+    background-color: #095615;
+    border-color: #095615;
+    text-decoration: none; }
+  .p-button--positive:disabled, .p-button--positive.is--disabled {
+    cursor: not-allowed;
+    opacity: .5; }
+    .p-button--positive:disabled:active, .p-button--positive:disabled:focus, .p-button--positive:disabled:hover, .p-button--positive.is--disabled:active, .p-button--positive.is--disabled:focus, .p-button--positive.is--disabled:hover {
+      background-color: #0e8420;
+      border-color: #0e8420; }
+  .p-button--positive .p-link--external {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23fff' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+
+.p-button--negative {
+  transition-duration: 0.165s;
+  transition-property: background-color;
+  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  background-color: #c7162b;
+  border-color: #c7162b;
+  border-radius: .125rem;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  color: #fff;
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 1rem;
+  font-smoothing: subpixel-antialiased;
+  font-weight: 300;
+  line-height: 1rem;
+  outline: none;
+  padding: 0.75rem 1.5rem;
+  text-align: center;
+  text-decoration: none;
+  width: 100%; }
+  @media only screen and (min-width: 768px) {
+    .p-button--negative {
+      width: auto; } }
+  .p-button--negative:visited {
+    color: #fff; }
+  .p-button--negative:active, .p-button--negative:focus, .p-button--negative:hover {
+    background-color: #991121;
+    border-color: #991121;
+    text-decoration: none; }
+  .p-button--negative:disabled, .p-button--negative.is--disabled {
+    cursor: not-allowed;
+    opacity: .5; }
+    .p-button--negative:disabled:active, .p-button--negative:disabled:focus, .p-button--negative:disabled:hover, .p-button--negative.is--disabled:active, .p-button--negative.is--disabled:focus, .p-button--negative.is--disabled:hover {
+      background-color: #c7162b;
+      border-color: #c7162b; }
+  .p-button--negative .p-link--external {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23fff' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+
+.p-button--base {
+  transition-duration: 0.165s;
+  transition-property: background-color;
+  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: .125rem;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  color: #111;
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 1rem;
+  font-smoothing: subpixel-antialiased;
+  font-weight: 300;
+  line-height: 1rem;
+  outline: none;
+  padding: 0.75rem 1.5rem;
+  text-align: center;
+  text-decoration: none;
+  width: 100%; }
+  @media only screen and (min-width: 768px) {
+    .p-button--base {
+      width: auto; } }
+  .p-button--base:visited {
+    color: #111; }
+  .p-button--base:active, .p-button--base:focus, .p-button--base:hover {
+    background-color: #f7f7f7;
+    border-color: transparent;
+    text-decoration: none; }
+  .p-button--base:disabled, .p-button--base.is--disabled {
+    cursor: not-allowed;
+    opacity: .5; }
+    .p-button--base:disabled:active, .p-button--base:disabled:focus, .p-button--base:disabled:hover, .p-button--base.is--disabled:active, .p-button--base.is--disabled:focus, .p-button--base.is--disabled:hover {
+      background-color: transparent;
+      border-color: #cdcdcd; }
+  .p-button--base .p-link--external {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+
+@media (max-width: 768px) {
+  [class^="p-button"].is-inline {
+    margin-top: 1.2rem; } }
+
+@media (min-width: 768px) {
+  [class^="p-button"].is-inline {
+    margin-left: 0.75rem;
+    width: auto; } }

--- a/src/common/style/vanilla/css/headings.css
+++ b/src/common/style/vanilla/css/headings.css
@@ -1,0 +1,53 @@
+.p-heading--one {
+  font-size: 2rem;
+  font-weight: 300;
+  line-height: 1.2; }
+  @media only screen and (min-width: 1030px) {
+    .p-heading--one {
+      font-size: 3rem;
+      line-height: 1.25; } }
+
+.p-heading--two {
+  font-size: 1.75rem;
+  font-weight: 300;
+  line-height: 1.25; }
+  @media only screen and (min-width: 1030px) {
+    .p-heading--two {
+      font-size: 2rem;
+      line-height: 1.25; } }
+  @media only screen and (min-width: 1030px) {
+    .p-heading--two {
+      font-size: 2.25rem;
+      line-height: 1.167; } }
+
+.p-heading--three {
+  font-size: 1.5rem;
+  font-weight: 300;
+  line-height: 1.154; }
+  @media only screen and (min-width: 1030px) {
+    .p-heading--three {
+      font-size: 1.75rem;
+      line-height: 1.286; } }
+
+.p-heading--four {
+  font-size: 1.375rem;
+  font-weight: 300;
+  line-height: 1.364; }
+  @media only screen and (min-width: 1030px) {
+    .p-heading--four {
+      font-size: 1.5rem;
+      line-height: 1.25; } }
+
+.p-heading--five {
+  font-size: 1.125rem;
+  font-weight: 300;
+  line-height: 1.264; }
+  @media only screen and (min-width: 1030px) {
+    .p-heading--five {
+      font-size: 1.25rem;
+      line-height: 1.143; } }
+
+.p-heading--six {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.412; }

--- a/src/common/style/vanilla/headings.scss
+++ b/src/common/style/vanilla/headings.scss
@@ -1,0 +1,4 @@
+@import 'vanilla-framework/scss/base_typography.scss';
+@import 'vanilla-framework/scss/patterns_headings.scss';
+
+@include vf-p-headings;


### PR DESCRIPTION
## Done

Added `vanilla-framework` and `node-sass` to dev dependencies to build patterns from vanilla as CSS modules.

Created a test pattern modules (buttons, headings, breadcrumbs) to build and added a npm script to run node-sass on them.

## QA

- Check out this feature branch
- Run `npm i` to install new dependencies
- Run `npm run build:vanilla-modules` to re-create files in `src/common/style/vanilla/css`


## Issue / Card

Fixes #863 

