### PR TITLE
Move repos search to redux

### DIFF
--- a/src/common/actions/repositories.js
+++ b/src/common/actions/repositories.js
@@ -5,6 +5,7 @@ export const REPOSITORIES_REQUEST = 'REPOSITORIES_REQUEST';
 export const REPOSITORIES_SUCCESS = 'REPOSITORIES_SUCCESS';
 export const REPOSITORIES_FAILURE = 'REPOSITORIES_FAILURE';
 export const REPOSITORIES_DELAYED = 'REPOSITORIES_DELAYED';
+export const REPOSITORIES_SEARCH = 'REPOSITORIES_SEARCH';
 
 export function fetchUserRepositories(pageNumber) {
   let path = '/api/github/repos';
@@ -45,5 +46,12 @@ export function fetchChainedUserRepos(page) {
           return dispatch(fetchChainedUserRepos(result.pageLinks.next));
         }
       });
+  };
+}
+
+export function searchRepos(searchTerm) {
+  return {
+    type: REPOSITORIES_SEARCH,
+    payload: searchTerm
   };
 }

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -49,7 +49,6 @@ class SelectRepositoriesPage extends Component {
           </div>
           <SelectRepositoryList
             onRefresh={ this.onRefresh.bind(this) }
-            searchTerm={ this.props.searchTerm }
           />
         </div>
       </div>

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import { fetchBuilds } from '../../actions/snap-builds';
-import { fetchUserRepositoriesAndSnaps } from '../../actions/repositories';
+import { fetchUserRepositoriesAndSnaps, searchRepos } from '../../actions/repositories';
 import { fetchUserOrganizations } from '../../actions/organizations';
 import SelectRepositoryList from '../select-repository-list';
 import { HeadingThree } from '../vanilla/heading';
@@ -12,13 +12,6 @@ import SearchInput from '../search-input';
 import styles from './select-repositories-page.css';
 
 class SelectRepositoriesPage extends Component {
-  constructor() {
-    super();
-
-    this.state = {
-      search: ''
-    };
-  }
 
   componentDidMount() {
     this.fetchUserData();
@@ -31,7 +24,7 @@ class SelectRepositoriesPage extends Component {
   }
 
   updateSearch(event) {
-    this.setState({ search: event.target.value });
+    this.props.dispatch(searchRepos(event.target.value));
   }
 
   render() {
@@ -50,13 +43,13 @@ class SelectRepositoriesPage extends Component {
             </HeadingThree>
             <SearchInput
               id="search-repos"
-              value={ this.state.search }
+              value={ this.props.searchTerm }
               onChange={ this.updateSearch.bind(this) }
             />
           </div>
           <SelectRepositoryList
             onRefresh={ this.onRefresh.bind(this) }
-            searchTerm={ this.state.search }
+            searchTerm={ this.props.searchTerm }
           />
         </div>
       </div>
@@ -96,6 +89,7 @@ SelectRepositoriesPage.propTypes = {
   entities: PropTypes.object.isRequired,
   user: PropTypes.object,
   snaps: PropTypes.object.isRequired,
+  searchTerm: PropTypes.string.isRequired,
   dispatch: PropTypes.func.isRequired
 };
 
@@ -104,14 +98,16 @@ function mapStateToProps(state) {
     auth,
     entities,
     user,
-    snaps
+    snaps,
+    repositories
   } = state;
 
   return {
     auth,
     entities,
     user,
-    snaps
+    snaps,
+    searchTerm: repositories.searchTerm
   };
 }
 

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -117,11 +117,11 @@ export class SelectRepositoryListComponent extends Component {
     let renderedRepos = null;
     let filteredRepos = ids;
 
-    if (this.props.searchTerm) {
+    if (this.props.repositories.searchTerm) {
       filteredRepos = ids.filter(
          (id) => {
            return this.props.entities.repos[id].fullName.toLowerCase().indexOf(
-                this.props.searchTerm.toLowerCase()) !== -1; }
+                this.props.repositories.searchTerm.toLowerCase()) !== -1; }
          );
     }
 
@@ -218,15 +218,14 @@ SelectRepositoryListComponent.propTypes = {
   hasFailedRepositories: PropTypes.bool,
   isUpdatingSnaps: PropTypes.bool,
   isAddingSnaps: PropTypes.bool,
-  onRefresh: PropTypes.func,
-  searchTerm: PropTypes.string
+  onRefresh: PropTypes.func
 };
 
 function mapStateToProps(state, ownProps) {
   const {
     user,
     entities,
-    repositories,
+    repositories
   } = state;
 
   return {

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -15,8 +15,9 @@ import {
   getSelectedRepositories,
   getReposToAdd,
   hasFailedRepositories,
-  isAddingSnaps
-} from '../../selectors/index.js';
+  isAddingSnaps,
+  getFilteredRepos
+} from '../../selectors';
 import styles from './styles.css';
 
 import PrivateReposInfo from '../private-repos-info/private-repos-info';
@@ -103,6 +104,7 @@ export class SelectRepositoryListComponent extends Component {
 
   renderRepoList() {
     const { ids, error, isFetching, isDelayed } = this.props.repositories;
+    const { filteredRepos } = this.props;
 
     if (isFetching && ids.length === 0) {
       return (
@@ -115,15 +117,6 @@ export class SelectRepositoryListComponent extends Component {
     }
 
     let renderedRepos = null;
-    let filteredRepos = ids;
-
-    if (this.props.repositories.searchTerm) {
-      filteredRepos = ids.filter(
-         (id) => {
-           return this.props.entities.repos[id].fullName.toLowerCase().indexOf(
-                this.props.repositories.searchTerm.toLowerCase()) !== -1; }
-         );
-    }
 
     if (!error) {
       renderedRepos = filteredRepos.map((id) => this.renderRepository(id));
@@ -218,6 +211,7 @@ SelectRepositoryListComponent.propTypes = {
   hasFailedRepositories: PropTypes.bool,
   isUpdatingSnaps: PropTypes.bool,
   isAddingSnaps: PropTypes.bool,
+  filteredRepos: PropTypes.array,
   onRefresh: PropTypes.func
 };
 
@@ -234,6 +228,7 @@ function mapStateToProps(state, ownProps) {
     entities,
     repositories, // ?repository-pagination
     isUpdatingSnaps: state.snaps.isFetching,
+    filteredRepos: getFilteredRepos(state),
     isAddingSnaps: isAddingSnaps(state),
     selectedRepositories: getSelectedRepositories(state),
     reposToAdd: getReposToAdd(state),

--- a/src/common/reducers/repositories.js
+++ b/src/common/reducers/repositories.js
@@ -7,6 +7,7 @@ export function repositories(state = {
   isDelayed: false,
   error: null,
   ids: [],
+  searchTerm: '',
   pageLinks: {}
 }, action) {
 
@@ -36,6 +37,11 @@ export function repositories(state = {
       return {
         ...state,
         isDelayed: true
+      };
+    case ActionTypes.REPOSITORIES_SEARCH:
+      return {
+        ...state,
+        searchTerm: action.payload
       };
     default:
       return state;

--- a/src/common/selectors/index.js
+++ b/src/common/selectors/index.js
@@ -4,6 +4,7 @@ import pick from 'lodash/pick';
 import { parseGitHubRepoUrl } from '../helpers/github-url';
 
 const getRepositoriesIndex = state => state.repositories.ids;
+const getRepositoriesState = state => state.repositories;
 const getRepositories = state => state.entities.repos;
 const getRepositoryOwners = state => state.entities.owners;
 const getSnapsIndex = state => state.snaps.ids;
@@ -164,5 +165,20 @@ export const isAddingSnaps = createSelector(
   [getRepositoriesIndex, getRepositories],
   (repositoriesIndex, repositories) => {
     return !!(repositoriesIndex.length && repositoriesIndex.some((id) => repositories[id].isFetching));
+  }
+);
+
+/**
+ * @returns {Array} ids of repos that match the search term
+ */
+export const getFilteredRepos = createSelector(
+  [getRepositoriesIndex, getRepositoriesState, getRepositories],
+  (reposIds, reposState, repos) => {
+    return reposIds.filter((id) => {
+      const fullName = repos[id].fullName.toLowerCase();
+      const searchTerm = reposState.searchTerm.toLowerCase();
+
+      return fullName.indexOf(searchTerm) !== -1;
+    });
   }
 );

--- a/test/unit/src/common/actions/t_repositories.js
+++ b/test/unit/src/common/actions/t_repositories.js
@@ -2,10 +2,12 @@ import expect from 'expect';
 import nock from 'nock';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { isFSA } from 'flux-standard-action';
 
 import {
   fetchUserRepositories,
-  fetchChainedUserRepos
+  fetchChainedUserRepos,
+  searchRepos
 } from '../../../../../src/common/actions/repositories';
 import * as ActionTypes from '../../../../../src/common/actions/repositories';
 import callApi, { CALL_API } from '../../../../../src/common/middleware/call-api';
@@ -108,23 +110,33 @@ describe('repositories actions', () => {
         expect(requestActions.length).toBe(3);
       });
     });
-
   });
 
-  xcontext('searchRepos', () => {
+  describe('searchRepos', () => {
+    let store;
+
+    beforeEach(() => {
+      store = mockStore({});
+    });
 
     it('should create an action to update search term', () => {
-      // const expectedAction = {
-      //   type: ActionTypes.REPOSITORIES_SEARCH,
-      //   payload: 'test'
-      // };
-      //
-      // store.dispatch(searchRepos('test'));
-      // expect(store.getActions()).toInclude(expectedAction);
+      const expectedAction = {
+        type: ActionTypes.REPOSITORIES_SEARCH,
+        payload: 'test'
+      };
+
+      store.dispatch(searchRepos('test'));
+      expect(store.getActions()).toInclude(expectedAction);
     });
 
     it('should create a valid flux standard action', () => {
-      // expect(isFSA(action)).toBe(true);
+      const action = {
+        type: ActionTypes.REPOSITORIES_SEARCH,
+        payload: 'test'
+      };
+
+      store.dispatch(searchRepos('test'));
+      expect(isFSA(action)).toBe(true);
     });
   });
 });

--- a/test/unit/src/common/actions/t_repositories.js
+++ b/test/unit/src/common/actions/t_repositories.js
@@ -130,13 +130,7 @@ describe('repositories actions', () => {
     });
 
     it('should create a valid flux standard action', () => {
-      const action = {
-        type: ActionTypes.REPOSITORIES_SEARCH,
-        payload: 'test'
-      };
-
-      store.dispatch(searchRepos('test'));
-      expect(isFSA(action)).toBe(true);
+      expect(isFSA(searchRepos('test'))).toBe(true);
     });
   });
 });

--- a/test/unit/src/common/actions/t_repositories.js
+++ b/test/unit/src/common/actions/t_repositories.js
@@ -110,4 +110,21 @@ describe('repositories actions', () => {
     });
 
   });
+
+  xcontext('searchRepos', () => {
+
+    it('should create an action to update search term', () => {
+      // const expectedAction = {
+      //   type: ActionTypes.REPOSITORIES_SEARCH,
+      //   payload: 'test'
+      // };
+      //
+      // store.dispatch(searchRepos('test'));
+      // expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should create a valid flux standard action', () => {
+      // expect(isFSA(action)).toBe(true);
+    });
+  });
 });

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -187,8 +187,20 @@ describe('<SelectRepositoryListComponent /> instance', function() {
   });
 
   context('searching repositories', function() {
-    xit('should render only selected repositories', function() {
-      // TODO: implement
+    let wrapper;
+    let spy;
+
+    beforeEach(function() {
+      spy = spyOn(props, 'dispatch');
+      wrapper = shallow(<SelectRepositoryListComponent { ...props } />);
+    });
+
+    afterEach(function() {
+      spy.restore();
+    });
+
+    it('should render same number of rows as repos in filtered repos', function() {
+      expect(wrapper.find(SelectRepositoryRow).length).toBe(props.filteredRepos.length);
     });
   });
 });

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -188,15 +188,9 @@ describe('<SelectRepositoryListComponent /> instance', function() {
 
   context('searching repositories', function() {
     let wrapper;
-    let spy;
 
     beforeEach(function() {
-      spy = spyOn(props, 'dispatch');
       wrapper = shallow(<SelectRepositoryListComponent { ...props } />);
-    });
-
-    afterEach(function() {
-      spy.restore();
     });
 
     it('should render same number of rows as repos in filtered repos', function() {

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -52,7 +52,7 @@ describe('<SelectRepositoryListComponent /> instance', function() {
       },
       repositories: {
         isFetching: false,
-        ids: [1001,1002,1003]
+        ids: [1001,1002,1003],
       },
       snaps: {
         success: true,
@@ -61,6 +61,7 @@ describe('<SelectRepositoryListComponent /> instance', function() {
       enabledRepositories: { // stub the selector
         1001: {}
       },
+      filteredRepos: [1001,1002,1003],
       selectedRepositories: [], // stub the selector
       reposToAdd: [] // stub the selector
     };
@@ -182,6 +183,12 @@ describe('<SelectRepositoryListComponent /> instance', function() {
     it('should dispatch selected repositories for building on add button click', function() {
       wrapper.find('Button').last().simulate('click');
       expect(spy).toHaveBeenCalledWith(addRepos(testProps.reposToAdd));
+    });
+  });
+
+  context('searching repositories', function() {
+    xit('should render only selected repositories', function() {
+      // TODO: implement
     });
   });
 });

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -52,7 +52,7 @@ describe('<SelectRepositoryListComponent /> instance', function() {
       },
       repositories: {
         isFetching: false,
-        ids: [1001,1002,1003],
+        ids: [1001, 1002, 1003]
       },
       snaps: {
         success: true,
@@ -61,7 +61,7 @@ describe('<SelectRepositoryListComponent /> instance', function() {
       enabledRepositories: { // stub the selector
         1001: {}
       },
-      filteredRepos: [1001,1002,1003],
+      filteredRepos: [1001, 1002, 1003],
       selectedRepositories: [], // stub the selector
       reposToAdd: [] // stub the selector
     };

--- a/test/unit/src/common/reducers/t_repositories.js
+++ b/test/unit/src/common/reducers/t_repositories.js
@@ -9,6 +9,7 @@ describe('repositories reducers', () => {
     isFetching: false,
     isDelayed: false,
     pageLinks: {},
+    searchTerm: '',
     error: null,
     ids: []
   };
@@ -105,6 +106,20 @@ describe('repositories reducers', () => {
       expect(repositories(state, action)).toEqual({
         ...state,
         isDelayed: true
+      });
+    });
+  });
+
+  xcontext('REPOSITORIES_SEARCH', () => {
+    const action = {
+      type: ActionTypes.REPOSITORIES_SEARCH,
+      payload: 'test'
+    };
+
+    it('should store search term', () => {
+      // TODO: implement
+      expect(repositories(initialState, action)).toEqual({
+
       });
     });
   });

--- a/test/unit/src/common/reducers/t_repositories.js
+++ b/test/unit/src/common/reducers/t_repositories.js
@@ -110,16 +110,20 @@ describe('repositories reducers', () => {
     });
   });
 
-  xcontext('REPOSITORIES_SEARCH', () => {
+  context('REPOSITORIES_SEARCH', () => {
+    const state = {
+      ...initialState
+    };
+
     const action = {
       type: ActionTypes.REPOSITORIES_SEARCH,
       payload: 'test'
     };
 
     it('should store search term', () => {
-      // TODO: implement
-      expect(repositories(initialState, action)).toEqual({
-
+      expect(repositories(state, action)).toEqual({
+        ...state,
+        searchTerm: 'test'
       });
     });
   });

--- a/test/unit/src/common/selectors/t_selectors.js
+++ b/test/unit/src/common/selectors/t_selectors.js
@@ -9,7 +9,8 @@ import {
   snapsWithRegisteredNameAndSnapcraftData,
   snapsWithRegisteredNameAndNoSnapcraftData,
   snapsWithNoBuilds,
-  isAddingSnaps
+  isAddingSnaps,
+  getFilteredRepos
 } from '../../../../../src/common/selectors';
 
 describe('selectors', function() {
@@ -308,17 +309,75 @@ describe('selectors', function() {
 
   });
 
-  xcontext('getFilteredRepos', function() {
-    it('should return all repos if search term is empty', function() {
+  context('getFilteredRepos', function() {
 
+    const stateSearchEmpty = {
+      entities: {
+        repos: {
+          1001: {
+            id: 1001,
+            fullName: 'canonical/snap-test'
+          },
+          1002: {
+            id: 1002,
+            fullName: 'canonical/bsi-test'
+          }
+        }
+      },
+      repositories: {
+        ids: [1001, 1002],
+        searchTerm: ''
+      }
+    };
+
+    const stateSearchMatch = {
+      entities: {
+        repos: {
+          1001: {
+            id: 1001,
+            fullName: 'canonical/snap-test'
+          },
+          1002: {
+            id: 1002,
+            fullName: 'canonical/bsi-test'
+          }
+        }
+      },
+      repositories: {
+        ids: [1001, 1002],
+        searchTerm: 'bsi'
+      }
+    };
+
+    const stateSearchNoMatch = {
+      entities: {
+        repos: {
+          1001: {
+            id: 1001,
+            fullName: 'canonical/snap-test'
+          },
+          1002: {
+            id: 1002,
+            fullName: 'canonical/bsi-test'
+          }
+        }
+      },
+      repositories: {
+        ids: [1001, 1002],
+        searchTerm: 'maas'
+      }
+    };
+
+    it('should return all repos if search term is empty', function() {
+      expect(getFilteredRepos(stateSearchEmpty)).toEqual([1001, 1002]);
     });
 
     it('should return filtered repos if search term matches', function() {
-
+      expect(getFilteredRepos(stateSearchMatch)).toEqual([1002]);
     });
 
     it('should return empty list if search term does not match any repos', function() {
-
+      expect(getFilteredRepos(stateSearchNoMatch)).toEqual([]);
     });
   });
 });

--- a/test/unit/src/common/selectors/t_selectors.js
+++ b/test/unit/src/common/selectors/t_selectors.js
@@ -308,4 +308,17 @@ describe('selectors', function() {
 
   });
 
+  xcontext('getFilteredRepos', function() {
+    it('should return all repos if search term is empty', function() {
+
+    });
+
+    it('should return filtered repos if search term matches', function() {
+
+    });
+
+    it('should return empty list if search term does not match any repos', function() {
+
+    });
+  });
 });


### PR DESCRIPTION
## Done

Moving repos search functionality out of component to redux store.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to add repos, you should (still) be able to search through repos
- Run `npm test`, all tests should pass

## Issue / Card

Fixes #330
