### PR TITLE
Show error when snapcraft.yaml in invalid

### DIFF
--- a/src/common/components/repository-row/dropdowns/configuration-error-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/configuration-error-dropdown.js
@@ -1,0 +1,61 @@
+import React, { PropTypes } from 'react';
+
+import { Row, Data, Dropdown } from '../../vanilla/table-interactive';
+
+import getTemplateUrl from './template-url.js';
+
+const ConfigurationErrorDropdown = ({ snap }) => {
+
+  // XXX
+  // to access info about yaml parse error (YAMLException, from js-yaml module)
+  //
+  //  snap.snapcraftData.error = {
+  //    name: "YAMLException"
+  //
+  //    // reason is a short message with reason of the error
+  //    reason: "bad indentation of a mapping entry"
+  //
+  //    // detailed message with position of the error, formatted for command line (assumes fixed width font)
+  //    message: "bad indentation of a mapping entry at line 2, column 7:↵      test: indent error↵          ^"
+  //
+  //    // mark contains detailed info about position of the error
+  //    mark: {
+  //      buffer: "name: yaml-parse-fail-test↵  test: indent error↵"
+  //      column: 6
+  //      line: 1
+  //      name: null
+  //      position: 33
+  //    }
+  //  }
+
+  return (
+    <Dropdown>
+      <Row>
+        <Data col="100">
+          <p>
+            The snapcraft.yaml can’t be used because it isn’t valid.
+          </p>
+          <p>
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={getTemplateUrl(snap)}
+            >
+              Edit snapcraft.yaml…
+            </a>
+          </p>
+        </Data>
+      </Row>
+    </Dropdown>
+  );
+};
+
+ConfigurationErrorDropdown.propTypes = {
+  snap: PropTypes.shape({
+    gitRepoUrl: PropTypes.string,
+    gitBranch: PropTypes.string,
+    snapcraftData: PropTypes.object
+  }),
+};
+
+export default ConfigurationErrorDropdown;

--- a/src/common/components/repository-row/dropdowns/index.js
+++ b/src/common/components/repository-row/dropdowns/index.js
@@ -3,8 +3,10 @@ import RemoveRepoDropdown from './remove-repo-dropdown';
 import UnconfiguredDropdown from './unconfigured-dropdown';
 import EditConfigDropdown from './edit-config-dropdown';
 import RegisterNameDropdown from './register-name-dropdown';
+import ConfigurationErrorDropdown from './configuration-error-dropdown';
 
 export {
+  ConfigurationErrorDropdown,
   NameMismatchDropdown,
   RemoveRepoDropdown,
   UnconfiguredDropdown,

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -79,14 +79,6 @@ const RESPONSE_GITHUB_OTHER = {
   }
 };
 
-const RESPONSE_SNAPCRAFT_YAML_PARSE_FAILED = {
-  status: 'error',
-  payload: {
-    code: 'snapcraft-yaml-parse-failed',
-    message: 'Failed to parse snapcraft.yaml'
-  }
-};
-
 const RESPONSE_SNAP_NOT_FOUND = {
   status: 'error',
   payload: {
@@ -227,8 +219,11 @@ export const internalGetSnapcraftYaml = async (owner, name, token) => {
           contents: yaml.safeLoad(response.body),
           path
         };
-      } catch (e) {
-        throw new PreparedError(400, RESPONSE_SNAPCRAFT_YAML_PARSE_FAILED);
+      } catch (error) {
+        return {
+          path,
+          error
+        };
       }
     } catch (error) {
       if (path !== paths[paths.length - 1] &&


### PR DESCRIPTION
## Done

* Returning details about error when snapcraft.yaml is invalid or not found in API response.
* Showing "Error" instead of "Not configured" when snapcraft.yaml is found but invalid.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in
- Add a repo with invalid snapcraft.yaml (try some indent error, duplicated keys, etc)
- Repo should show an "Error" in configured column


## Issue / Card

Fixes #548

## Screenshots

<img width="1069" alt="screen shot 2017-07-24 at 16 47 41" src="https://user-images.githubusercontent.com/83575/28529138-0cabe230-7090-11e7-8bce-46434c0e03ea.png">

