### PR TITLE
328 prepopulate yml with registed name

### DIFF
--- a/src/common/components/repository-row/dropdowns/template-yaml.js
+++ b/src/common/components/repository-row/dropdowns/template-yaml.js
@@ -1,17 +1,16 @@
-export default function templateYaml(name, storeName) {
-  let repoName = name;
-  let nameMsg;
+export default function templateYaml(repoName, storeName) {
+  let name;
 
   // If the snap isn't registed on the store change the first template line
   if (!storeName) {
-    nameMsg = `# After registering a name on build.snapcraft.io, commit an uncommented line:
+    name = `# After registering a name on build.snapcraft.io, commit an uncommented line:
   # name: ${repoName}`;
   } else {
-    nameMsg = `name: ${repoName}`;
+    name = `name: ${repoName}`;
   }
 
   const template = `
-  ${nameMsg}
+  ${name}
   version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
   summary: Single-line elevator pitch for your amazing snap # 79 char long summary
   description: |

--- a/src/common/components/repository-row/dropdowns/template-yaml.js
+++ b/src/common/components/repository-row/dropdowns/template-yaml.js
@@ -1,18 +1,33 @@
-export default `
-name: my-snap-name # you probably want to 'snapcraft register <name>'
-version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
-summary: Single-line elevator pitch for your amazing snap # 79 char long summary
-description: |
-  This is my-snap's description. You have a paragraph or two to tell the
-  most important story about your snap. Keep it under 100 words though,
-  we live in tweetspace and your description wants to look good in the snap
-  store.
+export default function templateYaml(name, registered) {
+  let repoName = name;
+  let registeredName = registered;
 
-grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
+  if (!name) {
+    repoName = 'my-repo-name';
+  }
 
-parts:
-  my-part:
-    # See 'snapcraft plugins'
-    plugin: nil
-`;
+  if (!registered) {
+    registeredName = 'name';
+  }
+
+  const template = `
+  name: ${repoName} # you probably want to 'snapcraft register <${registeredName}>'
+  version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+  summary: Single-line elevator pitch for your amazing snap # 79 char long summary
+  description: |
+    This is my-snap's description. You have a paragraph or two to tell the
+    most important story about your snap. Keep it under 100 words though,
+    we live in tweetspace and your description wants to look good in the snap
+    store.
+
+  grade: devel # must be 'stable' to release into candidate/stable channels
+  confinement: devmode # use 'strict' once you have the right plugs and slots
+
+  parts:
+    my-part:
+      # See 'snapcraft plugins'
+      plugin: nil
+  `;
+
+  return template;
+}

--- a/src/common/components/repository-row/dropdowns/template-yaml.js
+++ b/src/common/components/repository-row/dropdowns/template-yaml.js
@@ -1,17 +1,17 @@
-export default function templateYaml(name, registered) {
+export default function templateYaml(name, storeName) {
   let repoName = name;
-  let registeredName = registered;
+  let nameMsg;
 
-  if (!name) {
-    repoName = 'my-repo-name';
-  }
-
-  if (!registered) {
-    registeredName = 'name';
+  // If the snap isn't registed on the store change the first template line
+  if (!storeName) {
+    nameMsg = `# After registering a name on build.snapcraft.io, commit an uncommented line:
+  # name: ${repoName}`;
+  } else {
+    nameMsg = `name: ${repoName}`;
   }
 
   const template = `
-  name: ${repoName} # you probably want to 'snapcraft register <${registeredName}>'
+  ${nameMsg}
   version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
   summary: Single-line elevator pitch for your amazing snap # 79 char long summary
   description: |

--- a/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
@@ -13,14 +13,15 @@ const LEARN_THE_BASICS_LINK = 'https://snapcraft.io/docs/build-snaps/your-first-
 const INSTALL_IT_LINK = 'https://snapcraft.io/create/';
 
 const getTemplateUrl = (snap) => {
-  const { fullName } = parseGitHubRepoUrl(snap.gitRepoUrl);
+  const { fullName, name } = parseGitHubRepoUrl(snap.gitRepoUrl);
+  // console.log(fullName);
   const templateUrl = url.format({
     protocol: 'https:',
     host: 'github.com',
     pathname: `${fullName}/new/${snap.gitBranch}`,
     query: {
       'filename': 'snap/snapcraft.yaml',
-      'value': templateYaml
+      'value': templateYaml()
     }
   });
 

--- a/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
@@ -14,14 +14,13 @@ const INSTALL_IT_LINK = 'https://snapcraft.io/create/';
 
 const getTemplateUrl = (snap) => {
   const { fullName, name } = parseGitHubRepoUrl(snap.gitRepoUrl);
-  // console.log(fullName);
   const templateUrl = url.format({
     protocol: 'https:',
     host: 'github.com',
     pathname: `${fullName}/new/${snap.gitBranch}`,
     query: {
       'filename': 'snap/snapcraft.yaml',
-      'value': templateYaml()
+      'value': templateYaml(name, snap.storeName)
     }
   });
 

--- a/test/unit/src/common/components/repository-row/dropdowns/t_unconfigured-dropdown.js
+++ b/test/unit/src/common/components/repository-row/dropdowns/t_unconfigured-dropdown.js
@@ -10,7 +10,8 @@ describe('<UnconfiguredDropdown />', () => {
   const props = {
     snap: {
       gitRepoUrl: 'https://github.com/anowner/aname',
-      gitBranch: 'dev'
+      gitBranch: 'dev',
+      storeName: 'aname'
     }
   };
 
@@ -25,7 +26,10 @@ describe('<UnconfiguredDropdown />', () => {
       protocol: 'https:',
       host: 'github.com',
       pathname: '/anowner/aname/new/dev',
-      query: { filename: 'snap/snapcraft.yaml', value: templateYaml }
+      query: {
+        filename: 'snap/snapcraft.yaml',
+        value: templateYaml('aname', 'aname')
+      }
     });
   });
 });


### PR DESCRIPTION
## Done

- Amended the pre-populated YAML content when configuring a .yml file.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to an unconfigured repo and click the dropdown and try to configure the YML. If the name isn't registered or is will give two outcomes as per issue #328  


## Issue / Card

Fixes #328

