### PR TITLE
Removing the repo-name from the yaml output

### DIFF
--- a/src/common/components/repository-row/dropdowns/template-yaml.js
+++ b/src/common/components/repository-row/dropdowns/template-yaml.js
@@ -4,7 +4,7 @@ export default function templateYaml(storeName) {
   // If the snap isn't registed on the store change the first template line
   if (!storeName) {
     name = `# After registering a name on build.snapcraft.io, commit an uncommented line:
-  # name: registered-name`;
+  # name: your-registered-name`;
   } else {
     name = `name: ${storeName}`;
   }

--- a/src/common/components/repository-row/dropdowns/template-yaml.js
+++ b/src/common/components/repository-row/dropdowns/template-yaml.js
@@ -1,4 +1,4 @@
-export default function templateYaml(repoName, storeName) {
+export default function templateYaml(storeName) {
   let name;
 
   // If the snap isn't registed on the store change the first template line
@@ -6,7 +6,7 @@ export default function templateYaml(repoName, storeName) {
     name = `# After registering a name on build.snapcraft.io, commit an uncommented line:
   # name: registered-name`;
   } else {
-    name = `name: ${repoName}`;
+    name = `name: ${storeName}`;
   }
 
   const template = `

--- a/src/common/components/repository-row/dropdowns/template-yaml.js
+++ b/src/common/components/repository-row/dropdowns/template-yaml.js
@@ -4,7 +4,7 @@ export default function templateYaml(repoName, storeName) {
   // If the snap isn't registed on the store change the first template line
   if (!storeName) {
     name = `# After registering a name on build.snapcraft.io, commit an uncommented line:
-  # name: ${repoName}`;
+  # name: registered-name`;
   } else {
     name = `name: ${repoName}`;
   }

--- a/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
@@ -13,14 +13,14 @@ const LEARN_THE_BASICS_LINK = 'https://snapcraft.io/docs/build-snaps/your-first-
 const INSTALL_IT_LINK = 'https://snapcraft.io/create/';
 
 const getTemplateUrl = (snap) => {
-  const { fullName, name } = parseGitHubRepoUrl(snap.gitRepoUrl);
+  const { fullName } = parseGitHubRepoUrl(snap.gitRepoUrl);
   const templateUrl = url.format({
     protocol: 'https:',
     host: 'github.com',
     pathname: `${fullName}/new/${snap.gitBranch}`,
     query: {
       'filename': 'snap/snapcraft.yaml',
-      'value': templateYaml(name, snap.storeName)
+      'value': templateYaml(snap.storeName)
     }
   });
 


### PR DESCRIPTION
## Done

- Replaced 'repo-name' out of the pre-populated yaml when a repo hasn't be registered at all

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to add repos and click and if a repo hasn't been configured click the get started template link for both a registered and un-registered repo


## Issue / Card

fixes #915 
