### PR TITLE
Properly checking snapcraft data existence when verifying name ownership

### DIFF
--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -289,7 +289,7 @@ export class RepositoryRowView extends Component {
 
     const registeredName = snap.storeName;
 
-    const isBuilt = !!(latestBuild && snap.snapcraftData && !snap.snapcraftData.error);
+    const isBuilt = !!(latestBuild && snapIsConfigured(snap));
 
     const isActive = (
       showNameMismatchDropdown ||
@@ -470,8 +470,7 @@ export class RepositoryRowView extends Component {
 
 const snapNameIsMismatched = (snap) => {
   const { snapcraftData, storeName } = snap;
-
-  return snapcraftData && storeName && snapcraftData.name !== storeName;
+  return snapIsConfigured(snap) && storeName && snapcraftData.name !== storeName;
 };
 
 const snapIsConfigured = (snap) => snap.snapcraftData && !snap.snapcraftData.error;


### PR DESCRIPTION
## Done

Fixed a regression error that showed up when registering a name because of issue in checking errors in snapcraft data.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Add a repo
- Try to register a name

No error should appear in user console, name should be properly registered.

## Issue / Card

Fixes #916 
