### PR TITLE
Workaround for knex hanging after all repositories are polled.

### DIFF
--- a/scripts/poller.js
+++ b/scripts/poller.js
@@ -2,4 +2,14 @@ import 'babel-polyfill';
 
 import { pollRepositories } from '../server/scripts/poller';
 
-pollRepositories();
+const p = pollRepositories();
+
+// Hack around knex hanging on DB connection forever.
+// See https://github.com/tgriesser/knex/issues/293
+p.then((lock) => {
+  const checkLock = () => {
+    if (!lock.isBusy()) { process.exit(); }
+    setTimeout(checkLock, 1000);
+  };
+  setTimeout(checkLock, 1000);
+});

--- a/src/server/scripts/poller.js
+++ b/src/server/scripts/poller.js
@@ -34,8 +34,7 @@ export const pollRepositories = (checker, builder) => {
   let AsyncLock = require('async-lock');
   let pollRepoLock = new AsyncLock();
 
-  let repoDB = db.model('Repository');
-  return repoDB.fetchAll().then(function (results) {
+  return db.model('Repository').fetchAll().then(function (results) {
     logger.info(`Iterating over ${results.length} repositories.`);
     results.models.forEach((repo) => {
       pollRepoLock.acquire('PROCESS-REPO-SYNC', async () => {
@@ -78,6 +77,9 @@ export const pollRepositories = (checker, builder) => {
         logger.info('==========');
       });
     });
+    // Pass the lock through so chained tasks can actually check
+    // for completion, if necessary.
+    return pollRepoLock;
   });
 };
 

--- a/test/unit/src/server/scripts/t_poller.js
+++ b/test/unit/src/server/scripts/t_poller.js
@@ -27,18 +27,21 @@ describe('Poller script helpers', function() {
     });
 
     context('when there are no repositories', function() {
-      it('does nothing', async () => {
+      let lock;
+      it('does nothing and returns the iteration lock', async () => {
         let checker = sinon.spy();
         let builder = sinon.spy();
-        await pollRepositories(checker, builder);
+        lock = await pollRepositories(checker, builder);
         expect(checker.callCount).toBe(0);
         expect(builder.callCount).toBe(0);
+        const AsyncLock = require('async-lock');
+        expect(lock).toBeA(AsyncLock);
       });
     });
 
     context('when the repository has no name in snapcraft.yaml', function() {
-      it('gets skipped', () => {
-        return db.transaction(async (trx) => {
+      it('gets skipped', async () => {
+        await db.transaction(async (trx) => {
           const db_user = db.model('GitHubUser').forge({
             github_id: 1234,
             name: null,
@@ -54,19 +57,18 @@ describe('Poller script helpers', function() {
             registrant_id: db_user.get('id')
           });
           await db_repo.save({}, { transacting: trx });
-        }).then(async () => {
-          let checker = sinon.spy();
-          let builder = sinon.spy();
-          await pollRepositories(checker, builder);
-          expect(checker.callCount).toBe(0);
-          expect(builder.callCount).toBe(0);
         });
+        let checker = sinon.spy();
+        let builder = sinon.spy();
+        await pollRepositories(checker, builder);
+        expect(checker.callCount).toBe(0);
+        expect(builder.callCount).toBe(0);
       });
     });
 
     context('when the repository has no name registered in the store', function() {
-      it('gets skipped', () => {
-        return db.transaction(async (trx) => {
+      it('gets skipped', async () => {
+        await db.transaction(async (trx) => {
           const db_user = db.model('GitHubUser').forge({
             github_id: 1234,
             name: null,
@@ -82,19 +84,18 @@ describe('Poller script helpers', function() {
             registrant_id: db_user.get('id')
           });
           await db_repo.save({}, { transacting: trx });
-        }).then(async () => {
-          let checker = sinon.spy();
-          let builder = sinon.spy();
-          await pollRepositories(checker, builder);
-          expect(checker.callCount).toBe(0);
-          expect(builder.callCount).toBe(0);
         });
+        let checker = sinon.spy();
+        let builder = sinon.spy();
+        await pollRepositories(checker, builder);
+        expect(checker.callCount).toBe(0);
+        expect(builder.callCount).toBe(0);
       });
     });
 
     context('when the repository snapcraft name does not match the one in the store', function() {
-      it('gets skipped', () => {
-        return db.transaction(async (trx) => {
+      it('gets skipped', async () => {
+        await db.transaction(async (trx) => {
           const db_user = db.model('GitHubUser').forge({
             github_id: 1234,
             name: null,
@@ -110,19 +111,18 @@ describe('Poller script helpers', function() {
             registrant_id: db_user.get('id')
           });
           await db_repo.save({}, { transacting: trx });
-        }).then(async () => {
-          let checker = sinon.spy();
-          let builder = sinon.spy();
-          await pollRepositories(checker, builder);
-          expect(checker.callCount).toBe(0);
-          expect(builder.callCount).toBe(0);
         });
+        let checker = sinon.spy();
+        let builder = sinon.spy();
+        await pollRepositories(checker, builder);
+        expect(checker.callCount).toBe(0);
+        expect(builder.callCount).toBe(0);
       });
     });
 
     context('when there are repositories with no changes', function() {
-      it('gets checked, but not built', () => {
-        return db.transaction(async (trx) => {
+      it('gets checked, but not built', async () => {
+        await db.transaction(async (trx) => {
           const db_user = db.model('GitHubUser').forge({
             github_id: 1234,
             name: null,
@@ -138,20 +138,19 @@ describe('Poller script helpers', function() {
             registrant_id: db_user.get('id')
           });
           await db_repo.save({}, { transacting: trx });
-        }).then(async () => {
-          let checker = sinon.stub().returns(false);
-          let builder = sinon.spy();
-          await pollRepositories(checker, builder);
-          expect(checker.callCount).toBe(1);
-          expect(checker.calledWithMatch('anowner', 'aname')).toBe(true);
-          expect(builder.callCount).toBe(0);
         });
+        let checker = sinon.stub().returns(false);
+        let builder = sinon.spy();
+        await pollRepositories(checker, builder);
+        expect(checker.callCount).toBe(1);
+        expect(checker.calledWithMatch('anowner', 'aname')).toBe(true);
+        expect(builder.callCount).toBe(0);
       });
     });
 
     context('when there are repositories with changes', function() {
-      it('gets built', () => {
-        return db.transaction(async (trx) => {
+      it('gets built', async () => {
+        await db.transaction(async (trx) => {
           const db_user = db.model('GitHubUser').forge({
             github_id: 1234,
             name: null,
@@ -167,15 +166,14 @@ describe('Poller script helpers', function() {
             registrant_id: db_user.get('id')
           });
           await db_repo.save({}, { transacting: trx });
-        }).then(async () => {
-          let checker = sinon.stub().returns(true);
-          let builder = sinon.spy();
-          await pollRepositories(checker, builder);
-          expect(checker.callCount).toBe(1);
-          expect(checker.calledWithMatch('anowner', 'aname')).toBe(true);
-          expect(builder.callCount).toBe(1);
-          expect(builder.calledWith('anowner', 'aname')).toBe(true);
         });
+        let checker = sinon.stub().returns(true);
+        let builder = sinon.spy();
+        await pollRepositories(checker, builder);
+        expect(checker.callCount).toBe(1);
+        expect(checker.calledWithMatch('anowner', 'aname')).toBe(true);
+        expect(builder.callCount).toBe(1);
+        expect(builder.calledWith('anowner', 'aname')).toBe(true);
       });
     });
 

--- a/test/unit/src/server/scripts/t_poller.js
+++ b/test/unit/src/server/scripts/t_poller.js
@@ -27,11 +27,10 @@ describe('Poller script helpers', function() {
     });
 
     context('when there are no repositories', function() {
-      let lock;
       it('does nothing and returns the iteration lock', async () => {
         let checker = sinon.spy();
         let builder = sinon.spy();
-        lock = await pollRepositories(checker, builder);
+        const lock = await pollRepositories(checker, builder);
         expect(checker.callCount).toBe(0);
         expect(builder.callCount).toBe(0);
         const AsyncLock = require('async-lock');


### PR DESCRIPTION
## Done

Workaround knex issue which hangs the poller script after the loop is complete.
See https://github.com/tgriesser/knex/issues/293

## QA

```npm run build:scripts 2>&1 > /dev/null && npm run poll-repositories -- --env=environments/dev.env```

It does not hang for few seconds (with sqlite) or forever (with pgsql) after completion. 
