### PR TITLE
Showing build upload error message on build details

### DIFF
--- a/src/common/components/build-history/buildHistory.css
+++ b/src/common/components/build-history/buildHistory.css
@@ -1,0 +1,3 @@
+.notificationWrapper {
+  margin-bottom: 1em;
+}

--- a/src/common/components/build-history/index.js
+++ b/src/common/components/build-history/index.js
@@ -4,7 +4,9 @@ import { connect } from 'react-redux';
 import { snapBuildsInitialStatus } from '../../reducers/snap-builds';
 import BuildRow from '../build-row';
 import { Table, Head, Body, Row, Header } from '../vanilla/table-interactive';
-import { Message } from '../forms';
+import Notification from '../vanilla-modules/notification';
+
+import styles from './buildHistory.css';
 
 export const BuildHistory = (props) => {
   const { repository, success, builds } = props;
@@ -16,7 +18,11 @@ export const BuildHistory = (props) => {
   }
 
   if (!hasBuilds) {
-    return <Message status='info'>This snap has not been built yet.</Message>;
+    return (
+      <div className={styles.notificationWrapper}>
+        <Notification status='information' appearance="information">This snap has not been built yet.</Notification>
+      </div>
+    );
   }
 
   const buildRows = builds

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -5,7 +5,6 @@ import Helmet from 'react-helmet';
 import BuildRow from '../components/build-row';
 import { Table, Head, Body, Row, Header } from '../components/vanilla/table-interactive';
 import BuildLog from '../components/build-log';
-import { Message } from '../components/forms';
 import {
   HelpBox,
   HelpInstallSnap,
@@ -15,7 +14,7 @@ import { HeadingOne, HeadingThree } from '../components/vanilla-modules/heading'
 import { IconSpinner } from '../components/vanilla-modules/icons';
 import Breadcrumbs, { BreadcrumbsLink } from '../components/vanilla-modules/breadcrumbs';
 import BetaNotification from '../components/beta-notification';
-
+import Notification from '../components/vanilla-modules/notification';
 import withRepository from './with-repository';
 import withSnapBuilds from './with-snap-builds';
 
@@ -87,7 +86,7 @@ class BuildDetails extends Component {
           Build #{buildId}
         </HeadingOne>
         { error &&
-          <Message status='error'>{ error.message || error }</Message>
+          <Notification appearance='negative' status='error'>{ error.message || error }</Notification>
         }
         { build &&
           <div>
@@ -104,14 +103,14 @@ class BuildDetails extends Component {
                 <BuildRow repository={repository} {...build} />
               </Body>
             </Table>
+            {
+              showBuildUploadErrorMessage &&
+              <div className={ styles.strip }>
+                <HeadingThree>Build failed to release</HeadingThree>
+                <Notification appearance='negative' status='error'>{ build.storeUploadErrorMessage }</Notification>
+              </div>
+            }
             <div className={ styles.strip }>
-              {
-                showBuildUploadErrorMessage &&
-                <div>
-                  <HeadingThree>Build failed to release</HeadingThree>
-                  <Message status='error'>{ build.storeUploadErrorMessage }</Message>
-                </div>
-              }
               <HeadingThree>Build log</HeadingThree>
               <BuildLog logUrl={build.buildLogUrl} />
             </div>

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -27,6 +27,8 @@ class BuildDetails extends Component {
     const { error, isFetching } = this.props.snapBuilds;
 
     const buildFailed = (build.statusMessage === 'Failed to build');
+    const buildFailedToUpload = (build.storeUploadStatus === 'Failed to upload');
+
     let helpBox;
 
     if (buildFailed) {
@@ -101,6 +103,13 @@ class BuildDetails extends Component {
               </Body>
             </Table>
             <div className={ styles.strip }>
+              {
+                buildFailedToUpload &&
+                <div>
+                  <HeadingThree>Build failed to release</HeadingThree>
+                  <Message status='error'>{ build.storeUploadErrorMessage }</Message>
+                </div>
+              }
               <HeadingThree>Build log</HeadingThree>
               <BuildLog logUrl={build.buildLogUrl} />
             </div>

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -27,7 +27,9 @@ class BuildDetails extends Component {
     const { error, isFetching } = this.props.snapBuilds;
 
     const buildFailed = (build.statusMessage === 'Failed to build');
-    const buildFailedToUpload = (build.storeUploadStatus === 'Failed to upload');
+    const buildFailedToUpload = (build.storeUploadStatus === 'Failed to upload'
+                              || build.storeUploadStatus === 'Failed to release to channels');
+    const showBuildUploadErrorMessage = buildFailedToUpload && build.storeUploadErrorMessage;
 
     let helpBox;
 
@@ -104,7 +106,7 @@ class BuildDetails extends Component {
             </Table>
             <div className={ styles.strip }>
               {
-                buildFailedToUpload &&
+                showBuildUploadErrorMessage &&
                 <div>
                   <HeadingThree>Build failed to release</HeadingThree>
                   <Message status='error'>{ build.storeUploadErrorMessage }</Message>

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
 
 import BuildHistory from '../components/build-history';
-import { Message } from '../components/forms';
+import Notification from '../components/vanilla-modules/notification';
 import { IconSpinner } from '../components/vanilla-modules/icons';
 import { HelpBox, HelpCustom, HelpInstallSnap } from '../components/help';
 import { HeadingOne } from '../components/vanilla-modules/heading';
@@ -74,7 +74,7 @@ export class Builds extends Component {
 
   render() {
     const { user, repository } = this.props;
-    const { isFetching, success, error } = this.props.snapBuilds;
+    let { isFetching, success, error } = this.props.snapBuilds;
 
     // only show spinner when data is loading for the first time
     const isLoading = isFetching && !success;
@@ -103,7 +103,9 @@ export class Builds extends Component {
           <IconSpinner />
         }
         { error &&
-          <Message status='error'>{ error.message || error }</Message>
+          <div className={styles.strip}>
+            <Notification status='error' appearance='negative'>{ error.message || error }</Notification>
+          </div>
         }
         { this.renderHelpBoxes() }
       </div>

--- a/src/common/helpers/snap-builds.js
+++ b/src/common/helpers/snap-builds.js
@@ -222,6 +222,8 @@ export function snapBuildFromAPI(entry) {
     dateBuilt: entry.datebuilt,
     duration: entry.duration,
 
-    storeRevision: entry.store_upload_revision
+    storeRevision: entry.store_upload_revision,
+    storeUploadStatus: entry.store_upload_status,
+    storeUploadErrorMessage: entry.store_upload_error_message
   };
 }

--- a/test/unit/src/common/components/build-history/t_build-history.js
+++ b/test/unit/src/common/components/build-history/t_build-history.js
@@ -32,15 +32,15 @@ describe('<BuildHistory />', function() {
   it('should message if has no builds', function() {
     const props = Object.assign({}, testProps, { builds: [] });
 
-    expect(shallow(BuildHistory(props)).text())
-      .toBe('This snap has not been built yet.');
+    expect(shallow(BuildHistory(props)).html())
+      .toContain('This snap has not been built yet.');
   });
 
   it('should message if has falsey builds', function() {
     const props = Object.assign({}, testProps, { builds: false });
 
-    expect(shallow(BuildHistory(props)).text())
-      .toBe('This snap has not been built yet.');
+    expect(shallow(BuildHistory(props)).html())
+      .toContain('This snap has not been built yet.');
   });
 
   it('should sort builds by id', function() {


### PR DESCRIPTION
## Done

Simple showing of build upload error message (as returned by API).

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Add a snap that builds but fails to publish
- Go the the build page


## Issue / Card

Fixes #714 

## Screenshots

<img width="1055" alt="screen shot 2017-08-21 at 11 29 14" src="https://user-images.githubusercontent.com/83575/29518127-75011a50-8678-11e7-99f2-524d8a42973d.png">

