### PR TITLE
Replaced admin:repo_hook with write:repo_hook OAuth permission scope

### DIFF
--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -7,7 +7,7 @@ import { conf } from '../helpers/config';
 import { getMemcached } from '../helpers/memcached';
 import { internalListOrganizations, listOrganizationsCacheId, requestUser } from './github';
 
-const AUTH_SCOPE = 'admin:repo_hook read:org';
+const AUTH_SCOPE = 'write:repo_hook read:org';
 const GITHUB_AUTH_LOGIN_URL = conf.get('GITHUB_AUTH_LOGIN_URL');
 const GITHUB_AUTH_VERIFY_URL = conf.get('GITHUB_AUTH_VERIFY_URL');
 const GITHUB_AUTH_CLIENT_ID = conf.get('GITHUB_AUTH_CLIENT_ID');

--- a/test/routes/src/server/routes/t_github-auth.js
+++ b/test/routes/src/server/routes/t_github-auth.js
@@ -80,7 +80,7 @@ describe('The login route', () => {
         .get('/auth/authenticate')
         .expect((res) => {
           expect(url.parse(res.headers.location, true).query.scope)
-            .toBe('admin:repo_hook read:org');
+            .toBe('write:repo_hook read:org');
         })
         .end(done);
     });


### PR DESCRIPTION
## Done

Replaced `admin:repo_hook` with `write:repo_hook` OAuth permission scope.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Revoke your dev application access on GH
- Sign in to the app, GH permissions screen should appear
- GH should ask for 'Read & write' instead of 'Admin' access to repo webhooks.


## Issue / Card

Based on research in #904

## Screenshots

<img width="564" alt="screen shot 2017-08-22 at 15 03 38" src="https://user-images.githubusercontent.com/83575/29566733-21eac0c2-874b-11e7-8839-22e4bf12c2f7.png">

