### PR TITLE
Making sure all errors are properly sent in API responses

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -480,16 +480,9 @@ const internalFindSnaps = async (owner, token) => {
     }
     return snaps;
   } catch (error) {
-    // At least for the moment, we just wrap the error we get from
-    // Launchpad.
-    const text = await error.response.text();
-    throw new PreparedError(error.response.status, {
-      status: 'error',
-      payload: {
-        code: 'lp-error',
-        message: text
-      }
-    });
+    // At least for the moment, we just throw the error and let it be caught
+    // later and sent in the response
+    throw error;
   }
 };
 

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -455,35 +455,29 @@ const internalFindSnaps = async (owner, token) => {
     remainingPrefixes = urlPrefixes;
   }
 
-  try {
-    const result = await lpClient.named_get('/+snaps', 'findByURLPrefixes', {
-      parameters: {
-        url_prefixes: remainingPrefixes,
-        owner: `/~${username}`
-      }
-    });
-    // Split up results into separate cache entries so that they can help
-    // speed things up for other users in the same organizations.
-    const newSnapsByPrefix = remainingPrefixes.map((urlPrefix) => {
-      return result.entries.filter(
-        (snap) => snap.git_repository_url.startsWith(urlPrefix)
-      );
-    });
-    await Promise.all(zip(remainingPrefixes, newSnapsByPrefix).map(
-      ([urlPrefix, newSnaps]) => memcached.set(
-        getUrlPrefixCacheId(urlPrefix), newSnaps, 3600
-      )
-    ));
-    snaps = snaps.concat(result.entries);
-    for (const snap of snaps) {
-      await ensureWebhook(snap);
+  const result = await lpClient.named_get('/+snaps', 'findByURLPrefixes', {
+    parameters: {
+      url_prefixes: remainingPrefixes,
+      owner: `/~${username}`
     }
-    return snaps;
-  } catch (error) {
-    // At least for the moment, we just throw the error and let it be caught
-    // later and sent in the response
-    throw error;
+  });
+  // Split up results into separate cache entries so that they can help
+  // speed things up for other users in the same organizations.
+  const newSnapsByPrefix = remainingPrefixes.map((urlPrefix) => {
+    return result.entries.filter(
+      (snap) => snap.git_repository_url.startsWith(urlPrefix)
+    );
+  });
+  await Promise.all(zip(remainingPrefixes, newSnapsByPrefix).map(
+    ([urlPrefix, newSnaps]) => memcached.set(
+      getUrlPrefixCacheId(urlPrefix), newSnaps, 3600
+    )
+  ));
+  snaps = snaps.concat(result.entries);
+  for (const snap of snaps) {
+    await ensureWebhook(snap);
   }
+  return snaps;
 };
 
 // If we haven't yet initialized metrics related to the number of snaps for


### PR DESCRIPTION
## Done

Making sure any error is properly propagated to response, so it's easier to debug issues.

## Issue / Card

Related to #936
