### PR TITLE
Updated vanilla to 1.5.0 from npm and rebuilt vanilla css files

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1389,6 +1389,9 @@
     "validate-npm-package-license": {
       "version": "3.0.1"
     },
+    "vanilla-framework": {
+      "version": "1.5.0"
+    },
     "vary": {
       "version": "1.1.0"
     },

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "sanitize-html": "^1.14.1",
     "serve-favicon": "^2.4.0",
     "uuid": "^3.0.1",
+    "vanilla-framework": "^1.5.0",
     "winston": "^2.3.0",
     "winston-daily-rotate-file": "^1.4.2",
     "yargs": "^6.4.0"
@@ -135,7 +136,6 @@
     "style-loader": "^0.13.1",
     "supertest": "^2.0.0",
     "url-loader": "^0.5.7",
-    "vanilla-framework": "^1.5.0",
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.8.4",
     "webpack-hot-middleware": "^2.13.0"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "style-loader": "^0.13.1",
     "supertest": "^2.0.0",
     "url-loader": "^0.5.7",
-    "vanilla-framework": "git+https://git@github.com/vanilla-framework/vanilla-framework.git#e3b7034a1caf39e4ed87b9481d5fe0e9913c2b0f",
+    "vanilla-framework": "^1.5.0",
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.8.4",
     "webpack-hot-middleware": "^2.13.0"

--- a/src/common/style/vanilla/breadcrumbs.scss
+++ b/src/common/style/vanilla/breadcrumbs.scss
@@ -1,3 +1,4 @@
+@import 'vanilla-framework/scss/_utilities_clearfix.scss';
 @import 'vanilla-framework/scss/patterns_breadcrumbs.scss';
 
 @include vf-p-breadcrumbs;

--- a/src/common/style/vanilla/css/breadcrumbs.css
+++ b/src/common/style/vanilla/css/breadcrumbs.css
@@ -1,25 +1,21 @@
+.p-breadcrumbs::after {
+  clear: both;
+  content: '';
+  display: block; }
+
 .p-breadcrumbs {
   list-style: none;
   margin: 0;
   padding: 0;
   width: 100%; }
   .p-breadcrumbs__item {
-    display: inline-block;
-    margin: 0 0.75rem 0.25rem 0.25rem;
+    float: left;
+    margin: 0 0 0.25rem 0.25rem;
     position: relative; }
     .p-breadcrumbs__item:not(:first-of-type) {
-      margin-right: -.25rem;
       text-indent: 1rem; }
-    .p-breadcrumbs__item:first-of-type {
-      margin-right: -.25rem; }
     .p-breadcrumbs__item:not(:first-of-type)::before {
       content: '\203A';
       left: -.75rem;
       position: absolute;
       top: 0; }
-  .p-breadcrumbs__link {
-    color: #111;
-    font-weight: 400;
-    text-decoration: none; }
-    .p-breadcrumbs__link:hover {
-      color: #007aa6; }

--- a/src/common/style/vanilla/css/button.css
+++ b/src/common/style/vanilla/css/button.css
@@ -1,19 +1,15 @@
-.p-button {
+.p-button, .p-button--neutral, .p-button--brand, .p-button--positive, .p-button--negative, .p-button--base {
   transition-duration: 0.165s;
   transition-property: background-color;
   transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
-  background-color: #fff;
-  border-color: #cdcdcd;
   border-radius: .125rem;
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  color: #111;
   cursor: pointer;
   display: inline-block;
   font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 1rem;
-  font-smoothing: subpixel-antialiased;
   font-weight: 300;
   line-height: 1rem;
   outline: none;
@@ -21,228 +17,98 @@
   text-align: center;
   text-decoration: none;
   width: 100%; }
+  @media (max-width: 767px) {
+    .p-button + .p-button, .p-button--neutral + .p-button, .p-button--brand + .p-button, .p-button--positive + .p-button, .p-button--negative + .p-button, .p-button--base + .p-button, .p-button + .p-button--neutral, .p-button--neutral + .p-button--neutral, .p-button--brand + .p-button--neutral, .p-button--positive + .p-button--neutral, .p-button--negative + .p-button--neutral, .p-button--base + .p-button--neutral, .p-button + .p-button--brand, .p-button--neutral + .p-button--brand, .p-button--brand + .p-button--brand, .p-button--positive + .p-button--brand, .p-button--negative + .p-button--brand, .p-button--base + .p-button--brand, .p-button + .p-button--positive, .p-button--neutral + .p-button--positive, .p-button--brand + .p-button--positive, .p-button--positive + .p-button--positive, .p-button--negative + .p-button--positive, .p-button--base + .p-button--positive, .p-button + .p-button--negative, .p-button--neutral + .p-button--negative, .p-button--brand + .p-button--negative, .p-button--positive + .p-button--negative, .p-button--negative + .p-button--negative, .p-button--base + .p-button--negative, .p-button + .p-button--base, .p-button--neutral + .p-button--base, .p-button--brand + .p-button--base, .p-button--positive + .p-button--base, .p-button--negative + .p-button--base, .p-button--base + .p-button--base {
+      margin-top: 1rem; } }
+  @media (min-width: 768px) {
+    .p-button + .p-button, .p-button--neutral + .p-button, .p-button--brand + .p-button, .p-button--positive + .p-button, .p-button--negative + .p-button, .p-button--base + .p-button, .p-button + .p-button--neutral, .p-button--neutral + .p-button--neutral, .p-button--brand + .p-button--neutral, .p-button--positive + .p-button--neutral, .p-button--negative + .p-button--neutral, .p-button--base + .p-button--neutral, .p-button + .p-button--brand, .p-button--neutral + .p-button--brand, .p-button--brand + .p-button--brand, .p-button--positive + .p-button--brand, .p-button--negative + .p-button--brand, .p-button--base + .p-button--brand, .p-button + .p-button--positive, .p-button--neutral + .p-button--positive, .p-button--brand + .p-button--positive, .p-button--positive + .p-button--positive, .p-button--negative + .p-button--positive, .p-button--base + .p-button--positive, .p-button + .p-button--negative, .p-button--neutral + .p-button--negative, .p-button--brand + .p-button--negative, .p-button--positive + .p-button--negative, .p-button--negative + .p-button--negative, .p-button--base + .p-button--negative, .p-button + .p-button--base, .p-button--neutral + .p-button--base, .p-button--brand + .p-button--base, .p-button--positive + .p-button--base, .p-button--negative + .p-button--base, .p-button--base + .p-button--base {
+      margin-left: 1rem; } }
   @media only screen and (min-width: 768px) {
-    .p-button {
+    .p-button, .p-button--neutral, .p-button--brand, .p-button--positive, .p-button--negative, .p-button--base {
       width: auto; } }
+  .p-button:active, .p-button--neutral:active, .p-button--brand:active, .p-button--positive:active, .p-button--negative:active, .p-button--base:active, .p-button:focus, .p-button--neutral:focus, .p-button--brand:focus, .p-button--positive:focus, .p-button--negative:focus, .p-button--base:focus, .p-button:hover, .p-button--neutral:hover, .p-button--brand:hover, .p-button--positive:hover, .p-button--negative:hover, .p-button--base:hover {
+    text-decoration: none; }
+  .p-button:disabled, .p-button--neutral:disabled, .p-button--brand:disabled, .p-button--positive:disabled, .p-button--negative:disabled, .p-button--base:disabled, .is--disabled.p-button, .is--disabled.p-button--neutral, .is--disabled.p-button--brand, .is--disabled.p-button--positive, .is--disabled.p-button--negative, .is--disabled.p-button--base {
+    cursor: not-allowed;
+    opacity: .5; }
+
+.p-button {
+  background-color: #fff;
+  border-color: #cdcdcd;
+  color: #111; }
   .p-button:visited {
     color: #111; }
   .p-button:active, .p-button:focus, .p-button:hover {
     background-color: #f7f7f7;
-    border-color: #cdcdcd;
-    text-decoration: none; }
-  .p-button:disabled, .p-button.is--disabled {
-    cursor: not-allowed;
-    opacity: .5; }
-    .p-button:disabled:active, .p-button:disabled:focus, .p-button:disabled:hover, .p-button.is--disabled:active, .p-button.is--disabled:focus, .p-button.is--disabled:hover {
-      background-color: #fff;
-      border-color: #fff; }
-  .p-button .p-link--external {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+    border-color: #cdcdcd; }
+  .p-button:disabled:active, .p-button:disabled:focus, .p-button:disabled:hover, .p-button.is--disabled:active, .p-button.is--disabled:focus, .p-button.is--disabled:hover {
+    background-color: #fff;
+    border-color: #fff; }
 
 .p-button--neutral {
-  transition-duration: 0.165s;
-  transition-property: background-color;
-  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   background-color: #fff;
   border-color: #cdcdcd;
-  border-radius: .125rem;
-  border-style: solid;
-  border-width: 1px;
-  box-sizing: border-box;
-  color: #111;
-  cursor: pointer;
-  display: inline-block;
-  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1rem;
-  font-smoothing: subpixel-antialiased;
-  font-weight: 300;
-  line-height: 1rem;
-  outline: none;
-  padding: 0.75rem 1.5rem;
-  text-align: center;
-  text-decoration: none;
-  width: 100%; }
-  @media only screen and (min-width: 768px) {
-    .p-button--neutral {
-      width: auto; } }
+  color: #111; }
   .p-button--neutral:visited {
     color: #111; }
   .p-button--neutral:active, .p-button--neutral:focus, .p-button--neutral:hover {
     background-color: #f7f7f7;
-    border-color: #cdcdcd;
-    text-decoration: none; }
-  .p-button--neutral:disabled, .p-button--neutral.is--disabled {
-    cursor: not-allowed;
-    opacity: .5; }
-    .p-button--neutral:disabled:active, .p-button--neutral:disabled:focus, .p-button--neutral:disabled:hover, .p-button--neutral.is--disabled:active, .p-button--neutral.is--disabled:focus, .p-button--neutral.is--disabled:hover {
-      background-color: transparent;
-      border-color: #cdcdcd; }
-  .p-button--neutral .p-link--external {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+    border-color: #cdcdcd; }
+  .p-button--neutral:disabled:active, .p-button--neutral:disabled:focus, .p-button--neutral:disabled:hover, .p-button--neutral.is--disabled:active, .p-button--neutral.is--disabled:focus, .p-button--neutral.is--disabled:hover {
+    background-color: transparent;
+    border-color: #cdcdcd; }
 
 .p-button--brand {
-  transition-duration: 0.165s;
-  transition-property: background-color;
-  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   background-color: #333;
   border-color: #333;
-  border-radius: .125rem;
-  border-style: solid;
-  border-width: 1px;
-  box-sizing: border-box;
-  color: #fff;
-  cursor: pointer;
-  display: inline-block;
-  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1rem;
-  font-smoothing: subpixel-antialiased;
-  font-weight: 300;
-  line-height: 1rem;
-  outline: none;
-  padding: 0.75rem 1.5rem;
-  text-align: center;
-  text-decoration: none;
-  width: 100%; }
-  @media only screen and (min-width: 768px) {
-    .p-button--brand {
-      width: auto; } }
+  color: #fff; }
   .p-button--brand:visited {
     color: #fff; }
   .p-button--brand:active, .p-button--brand:focus, .p-button--brand:hover {
     background-color: #1a1a1a;
-    border-color: #1a1a1a;
-    text-decoration: none; }
-  .p-button--brand:disabled, .p-button--brand.is--disabled {
-    cursor: not-allowed;
-    opacity: .5; }
-    .p-button--brand:disabled:active, .p-button--brand:disabled:focus, .p-button--brand:disabled:hover, .p-button--brand.is--disabled:active, .p-button--brand.is--disabled:focus, .p-button--brand.is--disabled:hover {
-      background-color: #333;
-      border-color: #333; }
-  .p-button--brand .p-link--external {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23fff' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+    border-color: #1a1a1a; }
+  .p-button--brand:disabled:active, .p-button--brand:disabled:focus, .p-button--brand:disabled:hover, .p-button--brand.is--disabled:active, .p-button--brand.is--disabled:focus, .p-button--brand.is--disabled:hover {
+    background-color: #333;
+    border-color: #333; }
 
 .p-button--positive {
-  transition-duration: 0.165s;
-  transition-property: background-color;
-  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   background-color: #0e8420;
   border-color: #0e8420;
-  border-radius: .125rem;
-  border-style: solid;
-  border-width: 1px;
-  box-sizing: border-box;
-  color: #fff;
-  cursor: pointer;
-  display: inline-block;
-  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1rem;
-  font-smoothing: subpixel-antialiased;
-  font-weight: 300;
-  line-height: 1rem;
-  outline: none;
-  padding: 0.75rem 1.5rem;
-  text-align: center;
-  text-decoration: none;
-  width: 100%; }
-  @media only screen and (min-width: 768px) {
-    .p-button--positive {
-      width: auto; } }
+  color: #fff; }
   .p-button--positive:visited {
     color: #fff; }
   .p-button--positive:active, .p-button--positive:focus, .p-button--positive:hover {
     background-color: #095615;
-    border-color: #095615;
-    text-decoration: none; }
-  .p-button--positive:disabled, .p-button--positive.is--disabled {
-    cursor: not-allowed;
-    opacity: .5; }
-    .p-button--positive:disabled:active, .p-button--positive:disabled:focus, .p-button--positive:disabled:hover, .p-button--positive.is--disabled:active, .p-button--positive.is--disabled:focus, .p-button--positive.is--disabled:hover {
-      background-color: #0e8420;
-      border-color: #0e8420; }
-  .p-button--positive .p-link--external {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23fff' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+    border-color: #095615; }
+  .p-button--positive:disabled:active, .p-button--positive:disabled:focus, .p-button--positive:disabled:hover, .p-button--positive.is--disabled:active, .p-button--positive.is--disabled:focus, .p-button--positive.is--disabled:hover {
+    background-color: #0e8420;
+    border-color: #0e8420; }
 
 .p-button--negative {
-  transition-duration: 0.165s;
-  transition-property: background-color;
-  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   background-color: #c7162b;
   border-color: #c7162b;
-  border-radius: .125rem;
-  border-style: solid;
-  border-width: 1px;
-  box-sizing: border-box;
-  color: #fff;
-  cursor: pointer;
-  display: inline-block;
-  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1rem;
-  font-smoothing: subpixel-antialiased;
-  font-weight: 300;
-  line-height: 1rem;
-  outline: none;
-  padding: 0.75rem 1.5rem;
-  text-align: center;
-  text-decoration: none;
-  width: 100%; }
-  @media only screen and (min-width: 768px) {
-    .p-button--negative {
-      width: auto; } }
+  color: #fff; }
   .p-button--negative:visited {
     color: #fff; }
   .p-button--negative:active, .p-button--negative:focus, .p-button--negative:hover {
     background-color: #991121;
-    border-color: #991121;
-    text-decoration: none; }
-  .p-button--negative:disabled, .p-button--negative.is--disabled {
-    cursor: not-allowed;
-    opacity: .5; }
-    .p-button--negative:disabled:active, .p-button--negative:disabled:focus, .p-button--negative:disabled:hover, .p-button--negative.is--disabled:active, .p-button--negative.is--disabled:focus, .p-button--negative.is--disabled:hover {
-      background-color: #c7162b;
-      border-color: #c7162b; }
-  .p-button--negative .p-link--external {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23fff' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23fff' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+    border-color: #991121; }
+  .p-button--negative:disabled:active, .p-button--negative:disabled:focus, .p-button--negative:disabled:hover, .p-button--negative.is--disabled:active, .p-button--negative.is--disabled:focus, .p-button--negative.is--disabled:hover {
+    background-color: #c7162b;
+    border-color: #c7162b; }
 
 .p-button--base {
-  transition-duration: 0.165s;
-  transition-property: background-color;
-  transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
   background-color: transparent;
   border-color: transparent;
-  border-radius: .125rem;
-  border-style: solid;
-  border-width: 1px;
-  box-sizing: border-box;
-  color: #111;
-  cursor: pointer;
-  display: inline-block;
-  font-family: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1rem;
-  font-smoothing: subpixel-antialiased;
-  font-weight: 300;
-  line-height: 1rem;
-  outline: none;
-  padding: 0.75rem 1.5rem;
-  text-align: center;
-  text-decoration: none;
-  width: 100%; }
-  @media only screen and (min-width: 768px) {
-    .p-button--base {
-      width: auto; } }
+  color: #111; }
   .p-button--base:visited {
     color: #111; }
   .p-button--base:active, .p-button--base:focus, .p-button--base:hover {
     background-color: #f7f7f7;
-    border-color: transparent;
-    text-decoration: none; }
-  .p-button--base:disabled, .p-button--base.is--disabled {
-    cursor: not-allowed;
-    opacity: .5; }
-    .p-button--base:disabled:active, .p-button--base:disabled:focus, .p-button--base:disabled:hover, .p-button--base.is--disabled:active, .p-button--base.is--disabled:focus, .p-button--base.is--disabled:hover {
-      background-color: transparent;
-      border-color: #cdcdcd; }
-  .p-button--base .p-link--external {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='15'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z'/%3E%3Cpath d='M-1-1h16v16H-1'/%3E%3Cpath fill='%23111' d='M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z'/%3E%3Cpath fill='%23111' d='M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148'/%3E%3C/g%3E%3C/svg%3E"); }
+    border-color: transparent; }
+  .p-button--base:disabled:active, .p-button--base:disabled:focus, .p-button--base:disabled:hover, .p-button--base.is--disabled:active, .p-button--base.is--disabled:focus, .p-button--base.is--disabled:hover {
+    background-color: transparent;
+    border-color: #cdcdcd; }
 
 @media (max-width: 768px) {
   [class^="p-button"].is-inline {

--- a/src/common/style/vanilla/css/lists.css
+++ b/src/common/style/vanilla/css/lists.css
@@ -19,8 +19,8 @@
       border-bottom: 0; }
 
 .is-ticked {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Ccircle fill='%23666' cx='7' cy='7' r='7'/%3E%3Cpath fill='%23fff' d='M6.1 10.813L2.41 8.105l1.184-1.613L5.9 8.187l4.393-4.394 1.414 1.414z' /%3E%3C/svg%3E");
-  background-position: 0 0.25rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Ccircle fill='%23333' cx='7' cy='7' r='7'/%3E%3Cpath fill='%23fff' d='M6.1 10.813L2.41 8.105l1.184-1.613L5.9 8.187l4.393-4.394 1.414 1.414z' /%3E%3C/svg%3E");
+  background-position: 0 .3rem;
   background-repeat: no-repeat;
   padding-left: 25px; }
   .p-list--divided .is-ticked {
@@ -98,3 +98,58 @@
       .p-list-step__bullet {
         position: absolute;
         top: -5px; } }
+
+.p-stepped-list--detailed {
+  list-style: none;
+  padding: 0 2rem 0 3rem; }
+  @media (max-width: 1030px) {
+    .p-stepped-list--detailed {
+      margin-top: 2.5rem; } }
+  .p-stepped-list--detailed .p-list-step__item {
+    margin-bottom: 3rem; }
+    @media (min-width: 768px) {
+      .p-stepped-list--detailed .p-list-step__item {
+        display: flex;
+        margin: 0; }
+        .p-stepped-list--detailed .p-list-step__item > * {
+          width: 50%; } }
+  @media (min-width: 768px) {
+    .p-stepped-list--detailed .p-list-step__title {
+      padding-top: 2.75rem; } }
+  .p-stepped-list--detailed .p-list-step__content {
+    background: #fff;
+    color: #000;
+    margin-left: -4rem;
+    margin-right: -2rem;
+    margin-top: 2.5rem;
+    padding: 1.3333rem; }
+    @media (min-width: 768px) {
+      .p-stepped-list--detailed .p-list-step__content {
+        border-bottom: 1px solid #f7f7f7;
+        margin: .25rem 0 0;
+        padding: 2.5rem; } }
+  @media (min-width: 768px) {
+    .p-stepped-list--detailed .p-list-step__bullet {
+      left: -60px;
+      margin-left: 0;
+      margin-right: 1rem;
+      position: absolute;
+      top: 2.25rem; } }
+
+@media (min-width: 768px) {
+  @supports (columns: 1) {
+    [class*='p-list'].is-split {
+      columns: 2; }
+      [class*='p-list'].is-split .p-list__item {
+        display: inline-block;
+        width: 100%; } }
+  @supports not (columns: 1) {
+    [class*='p-list'].is-split {
+      display: flex;
+      flex-wrap: wrap; }
+      [class*='p-list'].is-split .p-list__item {
+        width: calc(50% - .5rem); } }
+  [class*='p-list'].is-split .p-list__item:last-of-type {
+    border-bottom: 1px dotted #cdcdcd; }
+  [class*='p-list'].is-split:nth-child(2n-1) {
+    margin-right: 1rem; } }

--- a/src/common/style/vanilla/css/notifications.css
+++ b/src/common/style/vanilla/css/notifications.css
@@ -6,6 +6,7 @@
   border-style: solid;
   border-top-width: 3px;
   box-shadow: 0 1px 5px 1px rgba(0, 0, 0, 0.2);
+  color: #111;
   font-size: 1rem;
   overflow: hidden;
   padding: .625rem;
@@ -32,6 +33,7 @@
   border-style: solid;
   border-top-width: 3px;
   box-shadow: 0 1px 5px 1px rgba(0, 0, 0, 0.2);
+  color: #111;
   font-size: 1rem;
   overflow: hidden;
   padding: .625rem;
@@ -50,6 +52,7 @@
   border-style: solid;
   border-top-width: 3px;
   box-shadow: 0 1px 5px 1px rgba(0, 0, 0, 0.2);
+  color: #111;
   font-size: 1rem;
   overflow: hidden;
   padding: .625rem;
@@ -68,6 +71,7 @@
   border-style: solid;
   border-top-width: 3px;
   box-shadow: 0 1px 5px 1px rgba(0, 0, 0, 0.2);
+  color: #111;
   font-size: 1rem;
   overflow: hidden;
   padding: .625rem;
@@ -86,6 +90,7 @@
   border-style: solid;
   border-top-width: 3px;
   box-shadow: 0 1px 5px 1px rgba(0, 0, 0, 0.2);
+  color: #111;
   font-size: 1rem;
   overflow: hidden;
   padding: .625rem;


### PR DESCRIPTION
## Done

Updates Vanilla to 1.5.0 from NPM.
Also updated CSS built from vanilla.

## QA

- Check out this feature branch
- Run `npm i` (to update local npm modules)
- vanilla-framework 1.5.0 should be installed
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to a page with breadcrumb (for example build details page)
- Breadcrumb should have new vanilla styles (with blue links)


## Issue / Card

Fixes #940

## Screenshots

<img width="311" alt="screen shot 2017-08-31 at 15 21 20" src="https://user-images.githubusercontent.com/83575/29925271-1285622e-8e60-11e7-94ed-3836c5d3bf0b.png">

