### PR TITLE
Deploying poller as a cronscript running hourly, default config.

### DIFF
--- a/charm/templates/snap-build-poller_cron.j2
+++ b/charm/templates/snap-build-poller_cron.j2
@@ -1,0 +1,3 @@
+# DO NOT EDIT: Managed by juju charm
+42 * * * * {{user}} cd {{code_dir}} && KNEX_CONFIG_PATH={{knex_config_path}} npm run poll-repositories >> {{logs_dir}}/poller.log 2>&1
+

--- a/charm/templates/snap-build-poller_logrotate.j2
+++ b/charm/templates/snap-build-poller_logrotate.j2
@@ -9,4 +9,5 @@
     daily
     dateext
     compress
-  }
+}
+

--- a/charm/templates/snap-build-poller_logrotate.j2
+++ b/charm/templates/snap-build-poller_logrotate.j2
@@ -1,0 +1,12 @@
+# DO NOT EDIT: Managed by juju charm
+
+{{logs_dir}}/poller.log {
+    missingok
+    notifempty
+
+    delaycompress
+    rotate 30
+    daily
+    dateext
+    compress
+  }


### PR DESCRIPTION
## Done

Deploying the poller (`npm run poll-repositories`) running hourly using the default configuration (dry-run, shared GH creds)
