### PR TITLE
Cope with dash specialties to source secrets.

### DIFF
--- a/charm/templates/snap-build-poller_cron.j2
+++ b/charm/templates/snap-build-poller_cron.j2
@@ -1,3 +1,3 @@
 # DO NOT EDIT: Managed by juju charm
-42 * * * * {{user}} cd {{code_dir}} && . secrets.env && /usr/bin/npm run poll-repositories  -- --env=environments/{{ environment }}.env >> {{logs_dir}}/poller.log 2>&1
+42 * * * * {{user}} cd {{code_dir}} && . ./secrets.env && /usr/bin/npm run poll-repositories  -- --env=environments/{{ environment }}.env >> {{logs_dir}}/poller.log 2>&1
 

--- a/charm/templates/snap-build-poller_secrets.j2
+++ b/charm/templates/snap-build-poller_secrets.j2
@@ -18,3 +18,4 @@ export POLLER_BUILD_THRESHOLD={{ poller_build_threshold }}
 {%- if poller_github_auth_token %}
 export POLLER_GITHUB_AUTH_TOKEN={{ poller_github_auth_token }}
 {%- endif %}
+


### PR DESCRIPTION
## Done

Specifying secrets.env path in a way dash likes it (`. ./secrets.env`) so the cronjob for poll-repositories can finally runs.