### PR TITLE
Add i386 builds by default

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -29,7 +29,7 @@ import { getSnapcraftYamlCacheId } from './github';
 // configurable.
 const DISTRIBUTION = 'ubuntu';
 const DISTRO_SERIES = 'xenial';
-const ARCHITECTURES = ['amd64', 'armhf'];
+const ARCHITECTURES = ['amd64', 'armhf', 'i386'];
 
 const RESPONSE_NOT_LOGGED_IN = {
   status: 'error',

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -160,8 +160,11 @@ describe('The Launchpad API endpoint', () => {
               'ws.op': 'new',
               git_repository_url: 'https://github.com/anowner/aname',
               auto_build: 'false',
-              processors: ['/+processors/amd64', '/+processors/armhf',
-                           '/+processors/i386']
+              processors: [
+                '/+processors/amd64',
+                '/+processors/armhf',
+                '/+processors/i386'
+              ]
             }))
             .reply(201, 'Created', { Location: snapUrl });
           lpApi.get(`/devel/~test-user/+snap/${snapName}`)

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -160,7 +160,8 @@ describe('The Launchpad API endpoint', () => {
               'ws.op': 'new',
               git_repository_url: 'https://github.com/anowner/aname',
               auto_build: 'false',
-              processors: ['/+processors/amd64', '/+processors/armhf']
+              processors: ['/+processors/amd64', '/+processors/armhf',
+                           '/+processors/i386']
             }))
             .reply(201, 'Created', { Location: snapUrl });
           lpApi.get(`/devel/~test-user/+snap/${snapName}`)


### PR DESCRIPTION
Add automatic i386 builds. Giving developers control over which architectures they care to build for will come with the "build on" advanced grammar in snapcraft.yaml, hopefully before the end of the month. By extension this controls what architectures developers are happy to receive failed to publish emails for, they want the build badge to turn red for, etc.

See also https://github.com/canonical-websites/build.snapcraft.io/issues/902. 