### PR TITLE
Coping with async-lock limit errors.

### DIFF
--- a/scripts/poller.js
+++ b/scripts/poller.js
@@ -6,7 +6,11 @@ import { pollRepositories } from '../server/scripts/poller';
 // Hack around knex hanging on DB connection forever.
 // See https://github.com/tgriesser/knex/issues/293
 const exitWhenDone = async () => {
-  await pollRepositories();
+  try {
+    await pollRepositories();
+  } catch (e) {
+    process.exit(1);
+  }
   process.exit();
 };
 exitWhenDone();

--- a/src/server/scripts/poller.js
+++ b/src/server/scripts/poller.js
@@ -29,9 +29,11 @@ export const pollRepositories = (checker) => {
 
   checker = checker || checkSnapRepository;
 
-  // XXX: meh! no ES6 import support, great library :-/
+  // XXX cprov 2017-10-06: meh! no ES6 import support e small maxPending
+  // default (1000, but we need 1 per registered repo in production),
+  // such a great library I found :-/
   let AsyncLock = require('async-lock');
-  let pollRepoLock = new AsyncLock();
+  let pollRepoLock = new AsyncLock({ maxPending: 10000 });
   let locked_promises = [];
 
   let poller_request_builds = false;


### PR DESCRIPTION
Also extending async-lock limit to 10k repositories for now, until we can think of a better solution.