### PR TITLE
Switch to babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015", "stage-0", "react"],
+  "presets": ["env", "stage-0", "react"],
   "plugins": [
     "react-hot-loader/babel",
     "transform-object-rest-spread",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-es2015-destructuring": "^6.16.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
-    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "babel-register": "^6.16.3",


### PR DESCRIPTION
## Done

babel-preset-es2015 now emits a warning telling us to use
babel-preset-env instead, so follow its advice.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Check that the site generally still works (this is a change to the transpiler toolchain, so there's no specific page affected)