### PR TITLE
Fix showing repositories not available on GH

### DIFF
--- a/src/common/components/repository-row/dropdowns/configuration-error-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/configuration-error-dropdown.js
@@ -27,23 +27,36 @@ const ConfigurationErrorDropdown = ({ snap }) => {
   //      position: 33
   //    }
   //  }
+  let content;
+
+  if (snap.gitBranch && snap.snapcraftData.error) {
+    content = (
+      <div>
+        <p>
+          The snapcraft.yaml can’t be used because it isn’t valid.
+        </p>
+        <p>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={getTemplateUrl(snap)}
+          >
+            Edit snapcraft.yaml…
+          </a>
+        </p>
+      </div>
+    );
+  } else {
+    content = (
+      <p>We cannot access this repository on GitHub.</p>
+    );
+  }
 
   return (
     <Dropdown>
       <Row>
         <Data col="100">
-          <p>
-            The snapcraft.yaml can’t be used because it isn’t valid.
-          </p>
-          <p>
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href={getTemplateUrl(snap)}
-            >
-              Edit snapcraft.yaml…
-            </a>
-          </p>
+          {content}
         </Data>
       </Row>
     </Dropdown>

--- a/src/common/components/repository-row/dropdowns/configuration-error-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/configuration-error-dropdown.js
@@ -48,7 +48,7 @@ const ConfigurationErrorDropdown = ({ snap }) => {
     );
   } else {
     content = (
-      <p>We cannot access this repository on GitHub.</p>
+      <p>Check whether the repo has been made private or deleted from GitHub.</p>
     );
   }
 

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -358,14 +358,14 @@ export class RepositoryRowView extends Component {
   }
 
   renderConfiguredStatus(snap) {
-    const { snapcraftData } = snap;
+    const { gitBranch, snapcraftData } = snap;
     let onClick, content;
 
     if (!snapcraftData || snapcraftData.error) {
       // if there is no snapcraftData or snapcraft data contains 404 error
       // show repo as not configured
-      if (!snapcraftData ||
-          (snapcraftData.error && snapcraftData.error.status === 404)) {
+      if (gitBranch && (!snapcraftData ||
+          (snapcraftData.error && snapcraftData.error.status === 404))) {
         onClick = this.onNotConfiguredClick.bind(this);
         content = <span>Not configured</span>;
       // otherwise show a configuration error
@@ -469,7 +469,7 @@ const snapNameIsMismatched = (snap) => {
   return snapIsConfigured(snap) && storeName && snapcraftData.name !== storeName;
 };
 
-const snapIsConfigured = (snap) => snap.snapcraftData && !snap.snapcraftData.error;
+const snapIsConfigured = (snap) => snap.gitBranch && snap.snapcraftData && !snap.snapcraftData.error;
 
 RepositoryRowView.propTypes = {
   snap: PropTypes.shape({

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -359,19 +359,22 @@ export class RepositoryRowView extends Component {
 
   renderConfiguredStatus(snap) {
     const { gitBranch, snapcraftData } = snap;
+    const isSnapcraftDataMissing = (
+      !snapcraftData || (snapcraftData.error && snapcraftData.error.status === 404)
+    );
+
     let onClick, content;
 
     if (!snapcraftData || snapcraftData.error) {
       // if there is no snapcraftData or snapcraft data contains 404 error
       // show repo as not configured
-      if (gitBranch && (!snapcraftData ||
-          (snapcraftData.error && snapcraftData.error.status === 404))) {
+      if (gitBranch && isSnapcraftDataMissing) {
         onClick = this.onNotConfiguredClick.bind(this);
         content = <span>Not configured</span>;
       // otherwise show a configuration error
       } else {
         onClick = this.onConfigurationErrorClick.bind(this);
-        content = <span>Error</span>;
+        content = <span>{ gitBranch ? 'Error' : 'Repo missing' }</span>;
       }
     } else if (snapNameIsMismatched(snap)){
       onClick = this.onNameMismatchClick.bind(this);

--- a/src/common/middleware/call-api.js
+++ b/src/common/middleware/call-api.js
@@ -71,7 +71,7 @@ export default (defaults) => () => (next) => (action) => {
     })
     .catch((error) => {
       clearTimeout(loadingTimeout);
-
+      error.action = action;
       if (failureType) {
         // if type of failure action is defined in settings
         // catch the error and pass it in failure action payload

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -151,46 +151,29 @@ export const getSnapcraftData = async (repositoryUrl, token) => {
     logger.error(`Error getting ${cacheId} from memcached: ${error}`);
   }
 
-  try {
-    const snapcraftYaml = await internalGetSnapcraftYaml(owner, name, token);
-    const snapcraftData = {};
+  const snapcraftYaml = await internalGetSnapcraftYaml(owner, name, token);
+  const snapcraftData = {};
 
-    if (snapcraftYaml.contents) {
-      for (const index of Object.keys(snapcraftYaml.contents)) {
-        if (SNAPCRAFT_INFO_WHITELIST.indexOf(index) >= 0) {
-          snapcraftData[index] = snapcraftYaml.contents[index];
-        }
+  if (snapcraftYaml.contents) {
+    for (const index of Object.keys(snapcraftYaml.contents)) {
+      if (SNAPCRAFT_INFO_WHITELIST.indexOf(index) >= 0) {
+        snapcraftData[index] = snapcraftYaml.contents[index];
       }
     }
-
-    // copy snapcraft.yaml path from repo into snapcraftData
-    //
-    // XXX we are mixing our custom `path` into data from snapcraft.yaml file
-    // currently there is no `path` defined in snapcraft syntax
-    // https://snapcraft.io/docs/build-snaps/syntax
-    // and also we whitelist only `name`, so no collision should occur
-    snapcraftData.path = snapcraftYaml.path;
-
-    // if there was parse error include it as well
-    snapcraftData.error = snapcraftYaml.error;
-    await getMemcached().set(cacheId, snapcraftData, 3600);
-    return snapcraftData;
-  } catch (error) {
-    if (error.status && error.body) {
-      // if it's PreparedError (with status code and body) return whole JSON
-      return {
-        error
-      };
-    } else if (error.message) {
-      return {
-        error: error.message
-      };
-    } else {
-      return {
-        error: `Error while reading snapcraft.yaml for ${repositoryUrl}`
-      };
-    }
   }
+
+  // copy snapcraft.yaml path from repo into snapcraftData
+  //
+  // XXX we are mixing our custom `path` into data from snapcraft.yaml file
+  // currently there is no `path` defined in snapcraft syntax
+  // https://snapcraft.io/docs/build-snaps/syntax
+  // and also we whitelist only `name`, so no collision should occur
+  snapcraftData.path = snapcraftYaml.path;
+
+  // if there was parse error include it as well
+  snapcraftData.error = snapcraftYaml.error;
+  await getMemcached().set(cacheId, snapcraftData, 3600);
+  return snapcraftData;
 };
 
 export const listRepositories = async (req, res) => {

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -13,6 +13,7 @@ import { getGitHubRootSecret, makeWebhookSecret } from './webhook';
 const logger = logging.getLogger('express');
 const SNAPCRAFT_INFO_WHITELIST = ['name', 'confinement'];
 
+// TODO: same in launchpad.js
 const RESPONSE_NOT_FOUND = {
   status: 'error',
   payload: {
@@ -101,7 +102,13 @@ export const internalListOrganizations = async (owner, token) => {
     const response = await requestGitHub.get('/user/orgs', {
       token, json: true
     });
-    await checkGitHubStatus(response);
+    await checkGitHubStatus(response, {
+      status: 'error',
+      payload: {
+        code: 'github-orgs-not-found',
+        message: 'Cannot access user organizations'
+      }
+    });
     await getMemcached().set(cacheId, response.body, 3600);
     return response.body;
   } catch (error) {

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -84,7 +84,7 @@ const RESPONSE_GITHUB_OTHER = {
   status: 'error',
   payload: {
     code: 'github-error-other',
-    message: 'Something went wrong when looking for snapcraft.yaml'
+    message: 'Something went wrong when calling GitHub API'
   }
 };
 
@@ -159,6 +159,7 @@ export const checkGitHubStatus = (response, notFoundError = RESPONSE_GITHUB_REPO
     }
     switch (body.message) {
       case 'Not Found':
+      case 'This repository is empty.':
         // repo or snapcraft.yaml not found
         throw new PreparedError(404, notFoundError);
       case 'Bad credentials':
@@ -167,7 +168,7 @@ export const checkGitHubStatus = (response, notFoundError = RESPONSE_GITHUB_REPO
       default:
         // Something else
         logger.error('GitHub API error:', response.statusCode, body);
-        throw new PreparedError(500, RESPONSE_GITHUB_OTHER);
+        throw new PreparedError(response.statusCode, RESPONSE_GITHUB_OTHER);
     }
   }
   return response;

--- a/src/server/helpers/prepared-error.js
+++ b/src/server/helpers/prepared-error.js
@@ -1,0 +1,39 @@
+import logging from '../logging';
+const logger = logging.getLogger('express');
+
+export class PreparedError extends Error {
+  constructor(status, body) {
+    super();
+    this.status = status;
+    this.body = body;
+  }
+}
+
+// Wrap errors in a promise chain so that they always end up as a
+// PreparedError.
+export const prepareError = async (error) => {
+  if (error.status && error.body) {
+    // The error comes with a prepared representation.
+    return error;
+  } else if (error.response) {
+    // if it's ResourceError from LP client at least for the moment
+    // we just wrap the error we get from LP
+    const text = await error.response.text();
+    logger.error('Launchpad API error:', text);
+    return new PreparedError(error.response.status, {
+      status: 'error',
+      payload: {
+        code: 'lp-error',
+        message: text
+      }
+    });
+  } else {
+    return new PreparedError(500, {
+      status: 'error',
+      payload: {
+        code: 'internal-error',
+        message: error.message
+      }
+    });
+  }
+};

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -372,13 +372,13 @@ describe('The Launchpad API endpoint', () => {
           .end(done);
       });
 
-      it('should return a body with a "github-snapcraft-yaml-not-found" ' +
+      it('should return a body with a "github-repository-not-found" ' +
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
           .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(hasMessage('github-snapcraft-yaml-not-found'))
+          .expect(hasMessage('github-repository-not-found'))
           .end(done);
       });
     });
@@ -2166,13 +2166,13 @@ describe('The Launchpad API endpoint', () => {
           .end(done);
       });
 
-      it('should return a body with a "github-snapcraft-yaml-not-found" ' +
+      it('should return a body with a "github-repository-not-found" ' +
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
           .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(hasMessage('github-snapcraft-yaml-not-found'))
+          .expect(hasMessage('github-repository-not-found'))
           .end(done);
       });
     });
@@ -2526,13 +2526,13 @@ describe('The Launchpad API endpoint', () => {
           .end(done);
       });
 
-      it('should return a body with a "github-snapcraft-yaml-not-found" ' +
+      it('should return a body with a "github-repository-not-found" ' +
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
           .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
-          .expect(hasMessage('github-snapcraft-yaml-not-found'))
+          .expect(hasMessage('github-repository-not-found'))
           .end(done);
       });
     });

--- a/test/unit/src/common/components/repository-row/t_repository-row.js
+++ b/test/unit/src/common/components/repository-row/t_repository-row.js
@@ -14,6 +14,7 @@ import {
 describe('<RepositoryRowView />', () => {
   const props = {
     snap: {
+      gitBranch: 'master',
       gitRepoUrl: 'https://github.com/anowner/aname',
       storeName: 'test-snap',
       snapcraftData: { name: 'test-snap' }


### PR DESCRIPTION
## Done

Updated getting repo data (branch and snapcraft.yaml) not to fail when repo doesn't exist.

Marking repo with "Error" instead of "Not configured" when it doesn't exist (or is not accessible) on GitHub.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in
- Add repository to BSI
- Remove this repo from GH (or make it private)
- Go back to "My repos" page

## Issue / Card

Fixes #968 

## Screenshots

<img width="990" alt="screen shot 2017-10-11 at 13 52 24" src="https://user-images.githubusercontent.com/83575/31439156-76e49eb0-ae8b-11e7-9fbf-08e4ca6f43a7.png">
