### PR TITLE
Adjust for current "missing namespace" response

### DIFF
--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -248,7 +248,7 @@ async function fetchAccountInfo(root, discharge) {
       if (payload.message.indexOf('has not signed agreement') !== -1) {
         data.signedAgreement = false;
       }
-      if (payload.message.indexOf('missing short namespace') !== -1) {
+      if (payload.message.indexOf('missing namespace') !== -1) {
         data.hasShortNamespace = false;
       }
       return data;

--- a/test/unit/src/common/actions/t_auth-store.js
+++ b/test/unit/src/common/actions/t_auth-store.js
@@ -496,9 +496,9 @@ describe('store authentication actions', () => {
         code: 'user-not-ready',
         message: 'Developer has not signed agreement.'
       };
-      const missingShortNamespaceError = {
+      const missingNamespaceError = {
         code: 'user-not-ready',
-        message: 'Developer profile is missing short namespace.'
+        message: 'Developer profile is missing namespace.'
       };
       const shortNamespaceInUseError = {
         code: 'conflict',
@@ -580,7 +580,7 @@ describe('store authentication actions', () => {
         beforeEach(() => {
           storeApi.get('/account')
             .query(true)
-            .reply(403, { error_list: [missingShortNamespaceError] });
+            .reply(403, { error_list: [missingNamespaceError] });
         });
 
         it('stores an error on failure to set the short ' +

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -342,7 +342,7 @@ describe('register name actions', () => {
               it('sets short namespace if unset', async () => {
                 const error = {
                   code: 'user-not-ready',
-                  message: 'Developer profile is missing short namespace.'
+                  message: 'Developer profile is missing namespace.'
                 };
                 storeApi
                   .get('/account')


### PR DESCRIPTION
In software-center-agent r4326, the store started responding with
"Developer profile is missing namespace." rather than "Developer profile
is missing short namespace."  It remains unfortunate that we don't have
a proper error code for this, but for the meantime let's at least adjust
to the current response.

Fixes #792; fixes #945.

QAing this will require creating a new account, so it's probably best to do this with a local build configured to point to staging.