### PR TITLE
Implementing build annotations.

### DIFF
--- a/migrations/20171023112606_build_annotations.js
+++ b/migrations/20171023112606_build_annotations.js
@@ -1,0 +1,17 @@
+
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.createTable('build_annotation', function(table) {
+      table.integer('build_id').notNullable();
+      table.text('reason');
+      table.timestamps();
+      table.primary('build_id');
+    })
+  ]);  
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.dropTable('build_annotation')
+  ]);
+};

--- a/src/common/helpers/build_annotation.js
+++ b/src/common/helpers/build_annotation.js
@@ -1,0 +1,22 @@
+/* Copyright 2016 Canonical Ltd.  This software is licensed under the
+ * GNU Affero General Public License version 3 (see the file LICENSE).
+ *
+ * Helpers for recording build annotations. 
+ */
+
+const BUILD_TRIGGERED_MANUALLY = 'triggered-manually';
+const BUILD_TRIGGERED_BY_WEBHOOK = 'triggered-by-webhook';
+const BUILD_TRIGGERED_BY_POLLER = 'triggered-by-poller';
+
+
+function getBuildId(build) {
+  return parseInt(build.self_link.split('/').pop(), 10);
+}
+
+
+export {
+  BUILD_TRIGGERED_MANUALLY,
+  BUILD_TRIGGERED_BY_WEBHOOK,
+  BUILD_TRIGGERED_BY_POLLER,
+  getBuildId
+};

--- a/src/server/db/models/build_annotation.js
+++ b/src/server/db/models/build_annotation.js
@@ -1,0 +1,11 @@
+
+export default function register(db) {
+  /* Schema:
+   *   build_id: Launchpad build ID (unique)
+   *   reason: reason why the build was triggered.
+   */
+  db.model('BuildAnnotation', {
+    tableName: 'build_annotation',
+    hasTimestamps: true
+  });
+}

--- a/src/server/db/models/index.js
+++ b/src/server/db/models/index.js
@@ -1,7 +1,9 @@
+import registerBuildAnnotation from './build_annotation';
 import registerGitHubUser from './github-user';
 import registerRepository from './repository';
 
 export default function register(db) {
+  registerBuildAnnotation(db);
   registerGitHubUser(db);
   registerRepository(db);
 }

--- a/src/server/db/models/repository.js
+++ b/src/server/db/models/repository.js
@@ -12,7 +12,6 @@ export default function register(db) {
    *   registrant: GitHub user who registered this repository in BSI
    *   created_at: creation datetime
    *   updated_at: update datetime
-   *   polled_at: last poll datetime
    */
   db.model('Repository', {
     tableName: 'repository',

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -760,7 +760,7 @@ export const requestSnapBuilds = async (req, res) => {
     const { owner, name } = await checkAdminPermissions(
       req.session, req.body.repository_url
     );
-    const reason = req.body.reason || 'Build requested manually';
+    const reason = req.body.reason || 'triggered-manually';
     const snap = await internalFindSnap(req.body.repository_url);
     const builds = await internalRequestSnapBuilds(snap, owner, name, reason);
     return res.status(201).send({

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -1,5 +1,6 @@
 import { createHmac } from 'crypto';
 
+import { BUILD_TRIGGERED_BY_WEBHOOK } from '../../common/helpers/build_annotation';
 import { getGitHubRepoUrl } from '../../common/helpers/github-url';
 import db from '../db';
 import { conf } from '../helpers/config';
@@ -54,7 +55,6 @@ const handlePing = async (req, res) => {
 const handleGitHubPush = async (req, res, owner, name) => {
   const repositoryUrl = getGitHubRepoUrl(owner, name);
   const cacheId = getSnapcraftYamlCacheId(repositoryUrl);
-  const reason = 'triggered-by-webhook';
   // Clear snap name cache before starting.
   // XXX cjwatson 2017-02-16: We could be smarter about this by looking at
   // the content of the push event.
@@ -68,7 +68,7 @@ const handleGitHubPush = async (req, res, owner, name) => {
       // XXX cjwatson 2017-02-16: Cache returned snap name, if any.
       await internalGetSnapcraftYaml(owner, name);
     }
-    await internalRequestSnapBuilds(snap, owner, name, reason);
+    await internalRequestSnapBuilds(snap, owner, name, BUILD_TRIGGERED_BY_WEBHOOK);
     logger.info(`Requested builds of ${repositoryUrl}.`);
     return res.status(200).send();
   } catch (error) {

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -54,6 +54,7 @@ const handlePing = async (req, res) => {
 const handleGitHubPush = async (req, res, owner, name) => {
   const repositoryUrl = getGitHubRepoUrl(owner, name);
   const cacheId = getSnapcraftYamlCacheId(repositoryUrl);
+  const reason = `${repositoryUrl} changed.`;
   // Clear snap name cache before starting.
   // XXX cjwatson 2017-02-16: We could be smarter about this by looking at
   // the content of the push event.
@@ -67,7 +68,7 @@ const handleGitHubPush = async (req, res, owner, name) => {
       // XXX cjwatson 2017-02-16: Cache returned snap name, if any.
       await internalGetSnapcraftYaml(owner, name);
     }
-    await internalRequestSnapBuilds(snap, owner, name);
+    await internalRequestSnapBuilds(snap, owner, name, reason);
     logger.info(`Requested builds of ${repositoryUrl}.`);
     return res.status(200).send();
   } catch (error) {

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -54,7 +54,7 @@ const handlePing = async (req, res) => {
 const handleGitHubPush = async (req, res, owner, name) => {
   const repositoryUrl = getGitHubRepoUrl(owner, name);
   const cacheId = getSnapcraftYamlCacheId(repositoryUrl);
-  const reason = `${repositoryUrl} changed.`;
+  const reason = 'triggered-by-webhook';
   // Clear snap name cache before starting.
   // XXX cjwatson 2017-02-16: We could be smarter about this by looking at
   // the content of the push event.

--- a/src/server/scripts/poller.js
+++ b/src/server/scripts/poller.js
@@ -102,7 +102,7 @@ export const pollRepositories = (checker) => {
           if (await checker(owner, name, last_built)) {
             logger.info(`${owner}/${name}: NEEDSBUILD`);
             if (poller_request_builds) {
-              const reason = 'Build requested due changes in parts.';
+              const reason = 'triggered-by-poller';
               await internalRequestSnapBuilds(snap, owner, name, reason);
               logger.info(`${owner}/${name}: Builds requested.`);
             } else {

--- a/src/server/scripts/poller.js
+++ b/src/server/scripts/poller.js
@@ -4,6 +4,7 @@ import raven from 'raven';
 import logging from '../logging';
 import { conf } from '../helpers/config';
 import db from '../db';
+import { BUILD_TRIGGERED_BY_POLLER } from '../../common/helpers/build_annotation';
 import {
   getGitHubRepoUrl,
   parseGitHubRepoUrl
@@ -102,8 +103,7 @@ export const pollRepositories = (checker) => {
           if (await checker(owner, name, last_built)) {
             logger.info(`${owner}/${name}: NEEDSBUILD`);
             if (poller_request_builds) {
-              const reason = 'triggered-by-poller';
-              await internalRequestSnapBuilds(snap, owner, name, reason);
+              await internalRequestSnapBuilds(snap, owner, name, BUILD_TRIGGERED_BY_POLLER);
               logger.info(`${owner}/${name}: Builds requested.`);
             } else {
               logger.info(`${owner}/${name}: Build requesting DISABLED.`);

--- a/src/server/scripts/poller.js
+++ b/src/server/scripts/poller.js
@@ -102,7 +102,8 @@ export const pollRepositories = (checker) => {
           if (await checker(owner, name, last_built)) {
             logger.info(`${owner}/${name}: NEEDSBUILD`);
             if (poller_request_builds) {
-              await internalRequestSnapBuilds(snap, owner, name);
+              const reason = 'Build requested due changes in parts.';
+              await internalRequestSnapBuilds(snap, owner, name, reason);
               logger.info(`${owner}/${name}: Builds requested.`);
             } else {
               logger.info(`${owner}/${name}: Build requesting DISABLED.`);
@@ -112,7 +113,13 @@ export const pollRepositories = (checker) => {
           }
         } catch (e) {
           raven_client.captureException(e);
-          logger.error(`${owner}/${name}: FAILED (${e.message || e})`);
+          var reason;
+          if (e.body && e.body.payload) {
+            reason = e.body.payload.message;
+          } else {
+            reason = e.message || e;
+          }
+          logger.error(`${owner}/${name}: FAILED (${reason})`);
         }
         logger.info('==========');
       });

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -1984,6 +1984,23 @@ describe('The Launchpad API endpoint', () => {
           });
         });
 
+        it('returns just created build annotations in payload', (done) => {
+          supertest(app)
+            .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
+            .send({ repository_url: 'https://github.com/anowner/aname' })
+            .expect((res) => {
+              expect(res.body.payload.build_annotations).toEqual({
+                1: { reason: BUILD_TRIGGERED_MANUALLY },
+                2: { reason: BUILD_TRIGGERED_MANUALLY }
+              });
+            })
+            .end((err) => {
+              api.done();
+              done(err);
+            });
+        });
+
         it('leaves builds_requested unmodified if it is unset', async () => {
           await supertest(app)
             .post('/launchpad/snaps/request-builds')

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -14,6 +14,10 @@ import {
 import launchpad from '../../../../../src/server/routes/launchpad';
 import db from '../../../../../src/server/db';
 import {
+  BUILD_TRIGGERED_BY_POLLER,
+  BUILD_TRIGGERED_MANUALLY,
+} from '../../../../../src/common/helpers/build_annotation';
+import {
   getDefaultBranchCacheId,
   getSnapcraftYamlCacheId,
   listOrganizationsCacheId
@@ -1956,8 +1960,8 @@ describe('The Launchpad API endpoint', () => {
             reasons[m.get('build_id')] = m.get('reason');
           }
           expect(reasons).toEqual({
-            '1': 'triggered-manually',
-            '2': 'triggered-manually',
+            1: BUILD_TRIGGERED_MANUALLY,
+            2: BUILD_TRIGGERED_MANUALLY
           });
         });
 
@@ -1967,7 +1971,7 @@ describe('The Launchpad API endpoint', () => {
             .set('X-CSRF-Token', 'blah')
             .send({
               repository_url: 'https://github.com/anowner/aname',
-              reason: 'testing-trigger'
+              reason: BUILD_TRIGGERED_BY_POLLER
             });
           const build_annotations = await db.model('BuildAnnotation').fetchAll();
           let reasons = {};
@@ -1975,8 +1979,8 @@ describe('The Launchpad API endpoint', () => {
             reasons[m.get('build_id')] = m.get('reason');
           }
           expect(reasons).toEqual({
-            '1': 'testing-trigger',
-            '2': 'testing-trigger',
+            1: BUILD_TRIGGERED_BY_POLLER,
+            2: BUILD_TRIGGERED_BY_POLLER
           });
         });
 

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -1956,8 +1956,8 @@ describe('The Launchpad API endpoint', () => {
             reasons[m.get('build_id')] = m.get('reason');
           }
           expect(reasons).toEqual({
-            '1': 'Build requested manually',
-            '2': 'Build requested manually',
+            '1': 'triggered-manually',
+            '2': 'triggered-manually',
           });
         });
 
@@ -1967,7 +1967,7 @@ describe('The Launchpad API endpoint', () => {
             .set('X-CSRF-Token', 'blah')
             .send({
               repository_url: 'https://github.com/anowner/aname',
-              reason: 'Testing ...'
+              reason: 'testing-trigger'
             });
           const build_annotations = await db.model('BuildAnnotation').fetchAll();
           let reasons = {};
@@ -1975,8 +1975,8 @@ describe('The Launchpad API endpoint', () => {
             reasons[m.get('build_id')] = m.get('reason');
           }
           expect(reasons).toEqual({
-            '1': 'Testing ...',
-            '2': 'Testing ...',
+            '1': 'testing-trigger',
+            '2': 'testing-trigger',
           });
         });
 

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -19,6 +19,10 @@ describe('The WebHook API endpoint', () => {
   app = Express();
   app.use(github);
 
+  beforeEach(async () => {
+    await db.model('BuildAnnotation').query().truncate();
+  });
+  
   afterEach(() => {
     nock.cleanAll();
   });
@@ -157,20 +161,16 @@ describe('The WebHook API endpoint', () => {
             });
           requestAutoBuilds = nock(lp_api_url)
             .post(`/devel${lp_snap_path}`, { 'ws.op': 'requestAutoBuilds' })
-            .reply(200, {
-              total_size: 2,
-              start: 0,
-              entries: [
-                {
-                  resource_type_link: `${lp_api_base}/#snap_build`,
-                  self_link: `${lp_api_base}${lp_snap_path}/+build/1`
-                },
-                {
-                  resource_type_link: `${lp_api_base}/#snap_build`,
-                  self_link: `${lp_api_base}${lp_snap_path}/+build/2`
-                }
-              ]
-            });
+            .reply(200, [
+              {
+                resource_type_link: `${lp_api_base}/#snap_build`,
+                self_link: `${lp_api_base}${lp_snap_path}/+build/1`
+              },
+              {
+                resource_type_link: `${lp_api_base}/#snap_build`,
+                self_link: `${lp_api_base}${lp_snap_path}/+build/2`
+              }
+            ]);
         });
 
         it('returns 200 OK and requests builds', (done) => {
@@ -307,20 +307,16 @@ describe('The WebHook API endpoint', () => {
               });
             requestAutoBuilds = nock(lp_api_url)
               .post(`/devel${lp_snap_path}`, { 'ws.op': 'requestAutoBuilds' })
-              .reply(200, {
-                total_size: 2,
-                start: 0,
-                entries: [
-                  {
-                    resource_type_link: `${lp_api_base}/#snap_build`,
-                    self_link: `${lp_api_base}${lp_snap_path}/+build/1`
-                  },
-                  {
-                    resource_type_link: `${lp_api_base}/#snap_build`,
-                    self_link: `${lp_api_base}${lp_snap_path}/+build/2`
-                  }
-                ]
-              });
+              .reply(200, [
+                {
+                  resource_type_link: `${lp_api_base}/#snap_build`,
+                  self_link: `${lp_api_base}${lp_snap_path}/+build/1`
+                },
+                {
+                  resource_type_link: `${lp_api_base}/#snap_build`,
+                  self_link: `${lp_api_base}${lp_snap_path}/+build/2`
+                }
+              ]);
           });
 
           it('returns 200 OK and requests builds', (done) => {

--- a/test/unit/src/server/scripts/t_poller.js
+++ b/test/unit/src/server/scripts/t_poller.js
@@ -25,6 +25,7 @@ describe('Poller script helpers', function() {
     let db_repo;
 
     beforeEach(async () => {
+      await db.model('BuildAnnotation').query().truncate();
       await db.model('Repository').query().truncate();
       await db.model('GitHubUser').query().del();
       return db.transaction(async (trx) => {
@@ -162,13 +163,25 @@ describe('Poller script helpers', function() {
             }]
           });
         lp.post(`/devel/~${LP_API_USERNAME}/+snap/a_snap`)
-          .reply(200, {});
+          .reply(200, [
+              { self_link: '+build/100' },
+              { self_link: '+build/101' }
+          ]);
 
         let checker = sinon.stub().returns(true);
         await pollRepositoriesMock(checker);
         expect(checker.callCount).toBe(1);
         expect(checker.calledWithMatch('anowner', 'aname')).toBe(true);
         expect(checker.getCall(0).args[2].format()).toBe(since.milliseconds(0).format());
+
+        expect(await db.model('BuildAnnotation').count()).toBe(2);
+        const annotations = await db.model('BuildAnnotation').fetchAll();
+        expect(annotations.models.map((m) => {
+          return { build_id: m.get('build_id'), reason: m.get('reason') };
+        }))
+          .toContain({ build_id: 100, reason: 'Build requested due changes in parts.' })
+          .toContain({ build_id: 101, reason: 'Build requested due changes in parts.' });
+
       });
     });
   });

--- a/test/unit/src/server/scripts/t_poller.js
+++ b/test/unit/src/server/scripts/t_poller.js
@@ -179,8 +179,8 @@ describe('Poller script helpers', function() {
         expect(annotations.models.map((m) => {
           return { build_id: m.get('build_id'), reason: m.get('reason') };
         }))
-          .toContain({ build_id: 100, reason: 'Build requested due changes in parts.' })
-          .toContain({ build_id: 101, reason: 'Build requested due changes in parts.' });
+          .toContain({ build_id: 100, reason: 'triggered-by-poller' })
+          .toContain({ build_id: 101, reason: 'triggered-by-poller' });
 
       });
     });


### PR DESCRIPTION
Recording `reason` (text) why builds are triggered (`/launchpad/snaps/request-builds`) and returning corresponding 'build_annotations' map when builds are retrieved (`/launchpad/builds`)
