### PR TITLE
Update snapcraft docs links

### DIFF
--- a/src/common/components/help/help-install-snap.js
+++ b/src/common/components/help/help-install-snap.js
@@ -4,7 +4,7 @@ import { CopyToClipboard, Tweet } from '../share';
 import { HeadingThree } from '../vanilla-modules/heading/';
 import styles from './help.css';
 
-const HELP_INSTALL_URL = 'https://snapcraft.io/docs/core/install';
+const HELP_INSTALL_URL = 'https://docs.snapcraft.io/core/install';
 
 export default class HelpInstallSnap extends Component {
   render() {
@@ -15,7 +15,7 @@ export default class HelpInstallSnap extends Component {
     // TODO more at https://github.com/canonical-websites/build.snapcraft.io/issues/655
     const tweet = `Install ${name} in seconds on Linux OSes:\n`
       + `sudo snap install ${name}\n\n`
-      + '(Don’t have snapd? https://snapcraft.io/docs/core/install)';
+      + '(Don’t have snapd? https://docs.snapcraft.io/core/install)';
 
     return (
       <div className={styles.helpFlexWrapper}>

--- a/src/common/components/help/help-promote-snap.js
+++ b/src/common/components/help/help-promote-snap.js
@@ -3,7 +3,7 @@ import React, { Component, PropTypes } from 'react';
 import { HeadingThree } from '../vanilla-modules/heading/';
 import styles from './help.css';
 
-const HELP_CHANNELS_URL = 'https://snapcraft.io/docs/reference/channels';
+const HELP_CHANNELS_URL = 'https://docs.snapcraft.io/reference/channels';
 
 export default class HelpPromoteSnap extends Component {
   render() {

--- a/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
@@ -9,8 +9,8 @@ import templateYaml from './template-yaml.js';
 
 import styles from './dropdowns.css';
 
-const LEARN_THE_BASICS_LINK = 'https://snapcraft.io/docs/build-snaps/your-first-snap';
-const INSTALL_IT_LINK = 'https://snapcraft.io/create/';
+const LEARN_THE_BASICS_LINK = 'https://docs.snapcraft.io/build-snaps/your-first-snap';
+const INSTALL_IT_LINK = 'https://docs.snapcraft.io/build-snaps/';
 
 const getTemplateUrl = (snap) => {
   const { fullName } = parseGitHubRepoUrl(snap.gitRepoUrl);


### PR DESCRIPTION
## Done

Now that docs for snapcraft have moved to new domain links to docs can be updated to avoid unnecessary redirects.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to repo or build page with help boxes, docs links should link to docs.snapcraft.io


## Issue / Card

Fixes #969 
