### PR TITLE
Added href to logout link to make it style properly on hover

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -25,6 +25,7 @@ export default class Header extends Component {
                   </span>
                 }
                 <a
+                  href="/auth/logout"
                   className={ styles.link }
                   onClick={ this.onLogoutClick.bind(this) }
                 >


### PR DESCRIPTION
## Done

Added href to sign out link in header to give it proper styling on hover (and to make it work without JS as well).

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in
- Hover over Sign out link in header - it should have proper styles and hand cursor


## Issue / Card

Fixes #975

