### PR TITLE
Fixing build_annotation PK ('build_id' instead of 'id')

### DIFF
--- a/src/server/db/models/build_annotation.js
+++ b/src/server/db/models/build_annotation.js
@@ -6,6 +6,7 @@ export default function register(db) {
    */
   db.model('BuildAnnotation', {
     tableName: 'build_annotation',
+    idAttribute: 'build_id',
     hasTimestamps: true
   });
 }

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -753,7 +753,9 @@ export const internalRequestSnapBuilds = async (snap, owner, name, reason) => {
   try {
     await db.transaction(async (trx) => {
       for (const ann of build_annotations) {
-        await db.model('BuildAnnotation').forge(ann).save({}, { transacting: trx });
+        await db.model('BuildAnnotation')
+            .forge(ann)
+            .save({}, { method: 'insert', transacting: trx });
       }
     });
   } catch (error) {

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -1552,7 +1552,7 @@ describe('The Launchpad API endpoint', () => {
         // Corresponding build_annotation.
         await db.model('BuildAnnotation')
           .forge({ build_id: 12345, reason: 'Testing ...' })
-          .save();
+          .save({}, { method: 'insert' });
 
         // when getting snap data from API (via self_link)
         nock(lp_api_url)


### PR DESCRIPTION
Working around knex/bookshelf being dumb (https://github.com/bookshelf/bookshelf/issues/853):

```
2017-10-27 19:00:55.094Z ERROR express "Error saving build annotations for 98768,98769,98770: error: insert into "build_annotation" ("build_id", "created_at", "reason", "updated_at") values ($1, $2, $3, $4) returning "id" - column "id" does not exist"
```
