### PR TITLE
Build trigger ui

### DIFF
--- a/src/common/components/build-row/buildRow.css
+++ b/src/common/components/build-row/buildRow.css
@@ -1,0 +1,8 @@
+.commitIcon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  position: relative;
+  top: 2px;
+  margin: 0 4px;
+}

--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -8,6 +8,8 @@ import BuildStatus from '../build-status';
 
 import * as buildAnnotation from '../../helpers/build_annotation';
 
+import styles from './buildRow.css';
+
 const getBuildTriggerMessage = (repository, reason, commitId) => {
   switch (reason) {
     case buildAnnotation.BUILD_TRIGGERED_MANUALLY:
@@ -19,11 +21,13 @@ const getBuildTriggerMessage = (repository, reason, commitId) => {
         return (
           <span>
             Commit
+            {' '}
             <a
               target="_blank"
               rel="noopener noreferrer"
               href={`https://github.com/bartaz/snap-build-test/commit/${commitId}`}
             >
+              <img className={ styles.commitIcon } src="https://assets.ubuntu.com/v1/95b0c093-git-commit.svg" alt="" />
               { commitId.substring(0,7) }
             </a>
           </span>

--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -6,6 +6,35 @@ import { Row, Data } from '../vanilla/table-interactive';
 import { BuildStatusColours } from '../../helpers/snap-builds.js';
 import BuildStatus from '../build-status';
 
+import * as buildAnnotation from '../../helpers/build_annotation';
+
+const getBuildTriggerMessage = (repository, reason, commitId) => {
+  switch (reason) {
+    case buildAnnotation.BUILD_TRIGGERED_MANUALLY:
+      return 'Manual build';
+    case buildAnnotation.BUILD_TRIGGERED_BY_POLLER:
+      return 'Dependency change';
+    case buildAnnotation.BUILD_TRIGGERED_BY_WEBHOOK:
+      if (commitId) {
+        return (
+          <span>
+            Commit
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={`https://github.com/bartaz/snap-build-test/commit/${commitId}`}
+            >
+              { commitId.substring(0,7) }
+            </a>
+          </span>
+        );
+      }
+      return 'Unknown';
+    default:
+      return 'Unknown';
+  }
+};
+
 const BuildRow = (props) => {
 
   const {
@@ -16,7 +45,9 @@ const BuildRow = (props) => {
     duration,
     colour,
     statusMessage,
-    dateStarted
+    dateStarted,
+    reason,
+    commitId
   } = props;
 
   let humanDuration;
@@ -33,19 +64,22 @@ const BuildRow = (props) => {
 
   return (
     <Row key={ buildId }>
-      <Data col="20">
+      <Data col="15">
         { buildUrl
           ? <Link to={buildUrl}>{`#${buildId}`}</Link>
           : <span>{`#${buildId}`}</span>
         }
       </Data>
-      <Data col="20">
+      <Data col="15">
         {architecture}
       </Data>
-      <Data col="20">
+      <Data col="15">
         {humanDuration}
       </Data>
-      <Data col="40">
+      <Data col="20">
+        { getBuildTriggerMessage(repository, reason, commitId) }
+      </Data>
+      <Data col="35">
         <BuildStatus
           link={buildUrl}
           colour={colour}
@@ -70,7 +104,9 @@ BuildRow.propTypes = {
   colour: PropTypes.oneOf(Object.values(BuildStatusColours)),
   statusMessage: PropTypes.string,
   dateStarted: PropTypes.string,
-  duration: PropTypes.string
+  duration: PropTypes.string,
+  reason: PropTypes.string,
+  commitId: PropTypes.string
 };
 
 export default BuildRow;

--- a/src/common/components/builds-list/index.js
+++ b/src/common/components/builds-list/index.js
@@ -29,10 +29,11 @@ export const BuildsList = (props) => {
     <Table>
       <Head>
         <Row>
-          <Header col="20">Number</Header>
-          <Header col="20">Architecture</Header>
-          <Header col="20">Duration</Header>
-          <Header col="40">Result</Header>
+          <Header col="15">Number</Header>
+          <Header col="15">Architecture</Header>
+          <Header col="15">Duration</Header>
+          <Header col="20">Build trigger</Header>
+          <Header col="35">Result</Header>
         </Row>
       </Head>
       <Body>

--- a/src/common/helpers/build_annotation.js
+++ b/src/common/helpers/build_annotation.js
@@ -1,12 +1,13 @@
 /* Copyright 2016 Canonical Ltd.  This software is licensed under the
  * GNU Affero General Public License version 3 (see the file LICENSE).
  *
- * Helpers for recording build annotations. 
+ * Helpers for recording build annotations.
  */
 
 const BUILD_TRIGGERED_MANUALLY = 'triggered-manually';
 const BUILD_TRIGGERED_BY_WEBHOOK = 'triggered-by-webhook';
 const BUILD_TRIGGERED_BY_POLLER = 'triggered-by-poller';
+const BUILD_TRIGGER_UNKNOWN = 'trigger-unknown';
 
 
 function getBuildId(build) {
@@ -18,5 +19,6 @@ export {
   BUILD_TRIGGERED_MANUALLY,
   BUILD_TRIGGERED_BY_WEBHOOK,
   BUILD_TRIGGERED_BY_POLLER,
+  BUILD_TRIGGER_UNKNOWN,
   getBuildId
 };

--- a/src/common/helpers/snap-builds.js
+++ b/src/common/helpers/snap-builds.js
@@ -231,3 +231,12 @@ export function snapBuildFromAPI(entry) {
 export function isBuildInProgress(build) {
   return build.statusMessage === 'In progress' || build.statusMessage === 'Building soon';
 }
+
+export const annotateSnapBuild = (buildAnnotations = {}) => {
+  return (build) => {
+    return {
+      ...build,
+      reason: buildAnnotations[build.buildId] ? buildAnnotations[build.buildId].reason : 'trigger-unknown'
+    };
+  };
+};

--- a/src/common/helpers/snap-builds.js
+++ b/src/common/helpers/snap-builds.js
@@ -24,6 +24,8 @@
 //   duration: '0:02:00.124039' // 'duration'
 // };
 
+import { BUILD_TRIGGER_UNKNOWN } from './build_annotation';
+
 export const BuildStatusColours = {
   BLUE: 'blue',
   GREEN: 'green',
@@ -210,6 +212,8 @@ export function snapBuildFromAPI(entry) {
 
     architecture: entry.arch_tag,
 
+    commitId: entry.revision_id,
+
     statusMessage,
     colour,
     icon,
@@ -236,7 +240,7 @@ export const annotateSnapBuild = (buildAnnotations = {}) => {
   return (build) => {
     return {
       ...build,
-      reason: buildAnnotations[build.buildId] ? buildAnnotations[build.buildId].reason : 'trigger-unknown'
+      reason: buildAnnotations[build.buildId] ? buildAnnotations[build.buildId].reason : BUILD_TRIGGER_UNKNOWN
     };
   };
 };

--- a/src/common/reducers/index.js
+++ b/src/common/reducers/index.js
@@ -5,7 +5,7 @@ import * as betaNotification from './beta-notification';
 import * as repository from './repository';
 import * as repositories from './repositories';
 import * as authError from './auth-error';
-import * as snapBuilds from './snap-builds';
+import { snapBuilds } from './snap-builds';
 import * as snaps from './snaps';
 import * as user from './user';
 import * as auth from './auth';
@@ -20,7 +20,7 @@ const rootReducer = combineReducers({
   ...betaNotification,
   ...repositories,
   ...repository,
-  ...snapBuilds,
+  snapBuilds,
   ...snaps,
   ...user,
   ...nameOwnership,

--- a/src/common/reducers/snap-builds.js
+++ b/src/common/reducers/snap-builds.js
@@ -1,5 +1,10 @@
 import * as ActionTypes from '../actions/snap-builds';
-import { snapBuildFromAPI } from '../helpers/snap-builds';
+import { snapBuildFromAPI, annotateSnapBuild } from '../helpers/snap-builds';
+
+export const getAnnotatedBuilds = (action) => {
+  const payload = action.payload.response.payload;
+  return payload.builds.map(snapBuildFromAPI).map(annotateSnapBuild(payload.build_annotations));
+};
 
 export const snapBuildsInitialStatus = {
   isFetching: false,
@@ -37,7 +42,7 @@ export function snapBuilds(state = {}, action) {
           ...state[action.payload.id],
           isFetching: false,
           success: true,
-          builds: action.payload.response.payload.builds.map(snapBuildFromAPI),
+          builds: getAnnotatedBuilds(action),
           error: null
         }
       };
@@ -48,7 +53,7 @@ export function snapBuilds(state = {}, action) {
           ...state[action.payload.id],
           isFetching: false,
           success: true,
-          builds: action.payload.response.payload.builds.map(snapBuildFromAPI).concat(state[action.payload.id].builds),
+          builds: getAnnotatedBuilds(action).concat(state[action.payload.id].builds),
           error: null
         }
       };

--- a/test/unit/src/common/components/build-row/t_build-row.js
+++ b/test/unit/src/common/components/build-row/t_build-row.js
@@ -4,7 +4,8 @@ import { shallow } from 'enzyme';
 import { Link } from 'react-router';
 
 import BuildRow from '../../../../../../src/common/components/build-row';
-import { Row } from '../../../../../../src/common/components/vanilla/table-interactive';
+import { Row, Data } from '../../../../../../src/common/components/vanilla/table-interactive';
+import { BUILD_TRIGGER_UNKNOWN } from '../../../../../../src/common/helpers/build_annotation';
 
 describe('<BuildRow />', function() {
   const TEST_BUILD = {
@@ -14,13 +15,23 @@ describe('<BuildRow />', function() {
     colour: 'green',
     statusMessage: 'Build test status',
     dateStarted: '2017-03-07T12:29:45.297305+00:00',
-    duration: '0:01:24.425045'
+    duration: '0:01:24.425045',
+    reason: BUILD_TRIGGER_UNKNOWN
   };
   const TEST_REPO = {
     fullName: 'anowner/aname'
   };
 
   let element;
+
+  it('should display build reason column', () => {
+    element = shallow(<BuildRow repository={TEST_REPO} {...TEST_BUILD} />);
+
+    expect(element.find('Data').length).toBe(5);
+
+    const column = shallow(element.find(Data).get(3));
+    expect(column.html()).toInclude('Unknown');
+  });
 
   context('when build log is available', () => {
     beforeEach(() => {

--- a/test/unit/src/common/helpers/t_snap-builds.js
+++ b/test/unit/src/common/helpers/t_snap-builds.js
@@ -8,6 +8,7 @@ import {
   UserFacingState
 } from '../../../../../src/common/helpers/snap-builds';
 
+import { BUILD_TRIGGER_UNKNOWN } from '../../../../../src/common/helpers/build_annotation';
 
 describe('snapBuildFromAPI helper', () => {
   const SNAP_BUILD_ENTRY = {
@@ -304,8 +305,12 @@ describe('annotateSnapBuild', () => {
       annotate = annotateSnapBuild(TEST_ANNOTATIONS);
     });
 
-    it('should annotate given build with true if build is in progress', () => {
+    it('should annotate given build with given reason', () => {
       expect(annotate({ buildId: '1234' }).reason).toBe('test1234');
+    });
+
+    it('should annotate given build with default reason if reason is invalid', () => {
+      expect(annotate({ buildId: '4321' }).reason).toBe(BUILD_TRIGGER_UNKNOWN);
     });
   });
 });

--- a/test/unit/src/common/helpers/t_snap-builds.js
+++ b/test/unit/src/common/helpers/t_snap-builds.js
@@ -1,6 +1,7 @@
 import expect from 'expect';
 
 import {
+  annotateSnapBuild,
   isBuildInProgress,
   snapBuildFromAPI,
   BuildStatusColours,
@@ -283,5 +284,28 @@ describe('isBuildInProgress', () => {
 
   it('should return false if build is not in progress', () => {
     expect(isBuildInProgress({ statusMessage: 'Failed to build' })).toBe(false);
+  });
+});
+
+describe('annotateSnapBuild', () => {
+  const TEST_ANNOTATIONS = {
+    '1234': { reason: 'test1234' },
+    '1235': { reason: 'test1235' }
+  };
+
+  it('should return a function', () => {
+    expect(annotateSnapBuild()).toBeA('function');
+  });
+
+  context('returned function', () => {
+    let annotate;
+
+    beforeEach(() => {
+      annotate = annotateSnapBuild(TEST_ANNOTATIONS);
+    });
+
+    it('should annotate given build with true if build is in progress', () => {
+      expect(annotate({ buildId: '1234' }).reason).toBe('test1234');
+    });
   });
 });

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -3,68 +3,88 @@ import expect from 'expect';
 import { getAnnotatedBuilds, snapBuilds, snapBuildsInitialStatus } from '../../../../../src/common/reducers/snap-builds';
 import * as ActionTypes from '../../../../../src/common/actions/snap-builds';
 
+const SNAP_BUILDS = [{
+  'can_be_rescored': false,
+  'builder_link': 'https://api.launchpad.net/devel/builders/lgw01-11',
+  'datebuilt': '2016-11-09T17:08:36.317805+00:00',
+  'distro_arch_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial/amd64',
+  'snap_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2',
+  'duration': '0:02:36.314039',
+  'can_be_cancelled': false,
+  'title': 'amd64 build of godd-test-2 snap package in ubuntu xenial-updates',
+  'buildstate': 'Currently building',
+  'requester_link': 'https://api.launchpad.net/devel/~cjwatson',
+  'http_etag': '\'d4a5173d51d6525b6d07709306bcfd65dbb68c5c-303718749dd6021eaf21d1a9eb4ae538de800de2\'',
+  'score': null,
+  'self_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/+build/9590',
+  'date_started': '2016-11-09T17:06:00.003766+00:00',
+  'resource_type_link': 'https://api.launchpad.net/devel/#snap_build',
+  'build_log_url': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/9590/+files/buildlog_snap_ubuntu_xenial_amd64_godd-test-2_BUILDING.txt.gz',
+  'pocket': 'Updates',
+  'dependencies': null,
+  'date_first_dispatched': '2016-11-09T17:06:00.003766+00:00',
+  'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
+  'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
+  'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/9590',
+  'datecreated': '2016-11-09T17:05:52.436792+00:00',
+  'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
+  'upload_log_url': null
+}, {
+  'can_be_rescored': false,
+  'builder_link': 'https://api.launchpad.net/devel/builders/lgw01-06',
+  'datebuilt': '2016-06-06T16:44:15.404592+00:00',
+  'distro_arch_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial/amd64',
+  'snap_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2',
+  'duration': '0:03:21.345313',
+  'can_be_cancelled': false,
+  'title': 'amd64 build of godd-test-2 snap package in ubuntu xenial-updates',
+  'buildstate': 'Failed to build',
+  'requester_link': 'https://api.launchpad.net/devel/~cjwatson',
+  'http_etag': '\'8e0a4c14356c8028f2b9ccb77312222ad045b388-b02297890f0ad92c486cfc11f279f452cb8f7dcc\'',
+  'score': null,
+  'self_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/+build/1149',
+  'date_started': '2016-06-06T16:40:54.059279+00:00',
+  'resource_type_link': 'https://api.launchpad.net/devel/#snap_build',
+  'build_log_url': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1149/+files/buildlog_snap_ubuntu_xenial_amd64_godd-test-2_BUILDING.txt.gz',
+  'pocket': 'Updates',
+  'dependencies': null,
+  'date_first_dispatched': '2016-06-06T16:40:54.059279+00:00',
+  'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
+  'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
+  'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1149',
+  'datecreated': '2016-06-06T16:40:51.698805+00:00',
+  'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
+  'upload_log_url': null
+}];
+
 describe('getAnnotatedBuilds', () => {
-  // TODO:
-  it('should be tested');
+  const id = 'dummy/repo';
+
+  it('should return builds with annotations', () => {
+    const action = {
+      type: ActionTypes.FETCH_BUILDS_SUCCESS,
+      payload: {
+        id,
+        response: {
+          payload: {
+            builds: SNAP_BUILDS,
+            build_annotations: {
+              '9590': { reason: 'test-annotation-1' },
+              '1149': { reason: 'test-annotation-2' }
+            }
+          }
+        }
+      }
+    };
+
+    expect(getAnnotatedBuilds(action)[0]).toInclude({ reason: 'test-annotation-1' });
+    expect(getAnnotatedBuilds(action)[1]).toInclude({ reason: 'test-annotation-2' });
+  });
 });
 
 describe('snapBuilds reducers', () => {
   const initialState = {};
   const initialStatus = snapBuildsInitialStatus;
-
-  const SNAP_BUILDS = [{
-    'can_be_rescored': false,
-    'builder_link': 'https://api.launchpad.net/devel/builders/lgw01-11',
-    'datebuilt': '2016-11-09T17:08:36.317805+00:00',
-    'distro_arch_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial/amd64',
-    'snap_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2',
-    'duration': '0:02:36.314039',
-    'can_be_cancelled': false,
-    'title': 'amd64 build of godd-test-2 snap package in ubuntu xenial-updates',
-    'buildstate': 'Currently building',
-    'requester_link': 'https://api.launchpad.net/devel/~cjwatson',
-    'http_etag': '\'d4a5173d51d6525b6d07709306bcfd65dbb68c5c-303718749dd6021eaf21d1a9eb4ae538de800de2\'',
-    'score': null,
-    'self_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/+build/9590',
-    'date_started': '2016-11-09T17:06:00.003766+00:00',
-    'resource_type_link': 'https://api.launchpad.net/devel/#snap_build',
-    'build_log_url': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/9590/+files/buildlog_snap_ubuntu_xenial_amd64_godd-test-2_BUILDING.txt.gz',
-    'pocket': 'Updates',
-    'dependencies': null,
-    'date_first_dispatched': '2016-11-09T17:06:00.003766+00:00',
-    'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-    'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
-    'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/9590',
-    'datecreated': '2016-11-09T17:05:52.436792+00:00',
-    'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
-    'upload_log_url': null
-  }, {
-    'can_be_rescored': false,
-    'builder_link': 'https://api.launchpad.net/devel/builders/lgw01-06',
-    'datebuilt': '2016-06-06T16:44:15.404592+00:00',
-    'distro_arch_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial/amd64',
-    'snap_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2',
-    'duration': '0:03:21.345313',
-    'can_be_cancelled': false,
-    'title': 'amd64 build of godd-test-2 snap package in ubuntu xenial-updates',
-    'buildstate': 'Failed to build',
-    'requester_link': 'https://api.launchpad.net/devel/~cjwatson',
-    'http_etag': '\'8e0a4c14356c8028f2b9ccb77312222ad045b388-b02297890f0ad92c486cfc11f279f452cb8f7dcc\'',
-    'score': null,
-    'self_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/+build/1149',
-    'date_started': '2016-06-06T16:40:54.059279+00:00',
-    'resource_type_link': 'https://api.launchpad.net/devel/#snap_build',
-    'build_log_url': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1149/+files/buildlog_snap_ubuntu_xenial_amd64_godd-test-2_BUILDING.txt.gz',
-    'pocket': 'Updates',
-    'dependencies': null,
-    'date_first_dispatched': '2016-06-06T16:40:54.059279+00:00',
-    'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-    'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
-    'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1149',
-    'datecreated': '2016-06-06T16:40:51.698805+00:00',
-    'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
-    'upload_log_url': null
-  }];
 
   const id = 'dummy/repo';
 

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -1,9 +1,12 @@
 import expect from 'expect';
 
-import { snapBuilds, snapBuildsInitialStatus } from '../../../../../src/common/reducers/snap-builds';
+import { getAnnotatedBuilds, snapBuilds, snapBuildsInitialStatus } from '../../../../../src/common/reducers/snap-builds';
 import * as ActionTypes from '../../../../../src/common/actions/snap-builds';
 
-import { snapBuildFromAPI } from '../../../../../src/common/helpers/snap-builds';
+describe('getAnnotatedBuilds', () => {
+  // TODO:
+  it('should be tested');
+});
 
 describe('snapBuilds reducers', () => {
   const initialState = {};
@@ -141,7 +144,7 @@ describe('snapBuilds reducers', () => {
     });
 
     it('should store builds on fetch success', () => {
-      expect(snapBuilds(state, action)[id].builds).toEqual(SNAP_BUILDS.map(snapBuildFromAPI));
+      expect(snapBuilds(state, action)[id].builds).toEqual(getAnnotatedBuilds(action));
     });
 
     it('should store success state', () => {
@@ -181,7 +184,7 @@ describe('snapBuilds reducers', () => {
     });
 
     it('should prepend requested builds on success', () => {
-      const expected = SNAP_BUILDS.map(snapBuildFromAPI).concat(state[id].builds);
+      const expected = getAnnotatedBuilds(action).concat(state[id].builds);
       expect(snapBuilds(state, action)[id].builds).toEqual(expected);
     });
 


### PR DESCRIPTION
## Done

Added a build trigger column to builds table.

Design: https://github.com/CanonicalLtd/snappy-design-squad/issues/107#issuecomment-339019031

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to a repo page, builds trigger column should be visible
- Trigger new builds manually or via webhook - they should have proper build trigger shown

## Issue / Card

Fixes #990 

## Screenshots

<img width="1000" alt="screen shot 2017-11-02 at 10 34 29" src="https://user-images.githubusercontent.com/83575/32319051-74184b3e-bfb9-11e7-811b-46c0c403e7d6.png">
<img width="992" alt="screen shot 2017-11-02 at 10 33 58" src="https://user-images.githubusercontent.com/83575/32319052-743aee78-bfb9-11e7-8246-3d52a2208955.png">

