### PR TITLE
Show 'Commit' as build trigger even if commit id is unknown.

### DIFF
--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -33,7 +33,7 @@ const getBuildTriggerMessage = (repository, reason, commitId) => {
           </span>
         );
       }
-      return 'Unknown';
+      return 'Commit';
     default:
       return 'Unknown';
   }

--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -25,7 +25,7 @@ const getBuildTriggerMessage = (repository, reason, commitId) => {
             <a
               target="_blank"
               rel="noopener noreferrer"
-              href={`https://github.com/bartaz/snap-build-test/commit/${commitId}`}
+              href={`${repository.url}/commit/${commitId}`}
             >
               <img className={ styles.commitIcon } src="https://assets.ubuntu.com/v1/95b0c093-git-commit.svg" alt="" />
               { commitId.substring(0,7) }

--- a/test/unit/src/common/components/build-row/t_build-row.js
+++ b/test/unit/src/common/components/build-row/t_build-row.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router';
 
 import BuildRow from '../../../../../../src/common/components/build-row';
 import { Row, Data } from '../../../../../../src/common/components/vanilla/table-interactive';
-import { BUILD_TRIGGER_UNKNOWN } from '../../../../../../src/common/helpers/build_annotation';
+import { BUILD_TRIGGER_UNKNOWN, BUILD_TRIGGERED_BY_WEBHOOK } from '../../../../../../src/common/helpers/build_annotation';
 
 describe('<BuildRow />', function() {
   const TEST_BUILD = {
@@ -31,6 +31,39 @@ describe('<BuildRow />', function() {
 
     const column = shallow(element.find(Data).get(3));
     expect(column.html()).toInclude('Unknown');
+  });
+
+  context('when build was triggered by webhook', () => {
+    it('should display commit as build reason', () => {
+      const build = {
+        ...TEST_BUILD,
+        reason: BUILD_TRIGGERED_BY_WEBHOOK
+      };
+
+      element = shallow(<BuildRow repository={TEST_REPO} {...build} />);
+
+      expect(element.find('Data').length).toBe(5);
+
+      const column = shallow(element.find(Data).get(3));
+      expect(column.html()).toInclude('Commit');
+    });
+
+    it('should display commit as build reason with link to GitHub', () => {
+      const build = {
+        ...TEST_BUILD,
+        reason: BUILD_TRIGGERED_BY_WEBHOOK,
+        commitId: 'ab1234'
+      };
+
+      element = shallow(<BuildRow repository={TEST_REPO} {...build} />);
+
+      expect(element.find('Data').length).toBe(5);
+
+      const column = shallow(element.find(Data).get(3));
+      expect(column.html()).toInclude('Commit');
+      expect(column.find('a').length).toBe(1);
+      expect(column.html()).toInclude('ab1234');
+    });
   });
 
   context('when build log is available', () => {


### PR DESCRIPTION
## Done

Show build triggered by webhook as 'Commit' even if commit id is not known yet (from LP API).

## QA

Is hard to QA locally as it requires webhook to work.

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Commit to a repo added to BSI
- Open repo page, new builds show have 'Commit' as build trigger
- Once the build proceeds commit id should be shown as well


## Issue / Card

Fixes #999 

## Screenshots

<img width="1055" alt="screen shot 2017-11-09 at 10 12 56" src="https://user-images.githubusercontent.com/83575/32597447-0b8efbac-c537-11e7-9a7f-0ed4bf0bbae7.png">

