### PR TITLE
Removing beta survey notification.

### DIFF
--- a/src/common/containers/app.js
+++ b/src/common/containers/app.js
@@ -5,8 +5,6 @@ import Helmet from 'react-helmet';
 import Header from '../components/header';
 import Footer from '../components/footer';
 
-import BetaNotificationTrigger from '../components/beta-notification/trigger';
-
 export class App extends Component {
   render() {
     return (
@@ -19,7 +17,6 @@ export class App extends Component {
             { 'name': 'description', 'content': 'build.snapcraft.io' },
           ]}
         />
-        <BetaNotificationTrigger />
         <Header
           authenticated={this.props.auth.authenticated}
           user={this.props.user}


### PR DESCRIPTION
## Done

As a follow up to #946 - dropping beta survey notification as well.


## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in
- Wait for 2 minutes - beta survey notification should not appear


## Issue / Card

Follow up on #946 
