### PR TITLE
Add npm version requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Snapcraft Build site.
 
 ## Local development
 
-First, make sure all dependencies are installed, you will need node@6 (for example version 6.11.3) and npm@4 (for example version 4.6.1):
+First, make sure all dependencies are installed, you will need node@6 (for example version 6.11.3) and npm in version less then 5 (for example npm@3 from nvm or npm@4):
 
 ``` bash
 $ npm install

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Snapcraft Build site.
 
 ## Local development
 
-First, make sure all dependencies are installed, you will need the version 6.11.3 of node:
+First, make sure all dependencies are installed, you will need node@6 (for example version 6.11.3) and npm@4 (for example version 4.6.1):
 
 ``` bash
 $ npm install


### PR DESCRIPTION
As npm@5 introduces changes that don't seem to work with our outdated dependencies we need to make sure we run older version of npm (like npm@4).