### PR TITLE
Pushing metrics for build_annotations.

### DIFF
--- a/src/server/metrics/build-annotation.js
+++ b/src/server/metrics/build-annotation.js
@@ -1,0 +1,21 @@
+import promClient from 'prom-client';
+
+import db from '../db';
+
+const buildAnnotationTotal = new promClient.Gauge(
+  'bsi_build_annotation_total',
+  'Total number of build annotations labelled by reason.',
+  ['metric_type', 'reason']
+);
+
+export default async function updateBuildAnnotationTotal(trx) {
+  const counters = await db.model('BuildAnnotation').query( function(q) {
+    q.select(db.knex.raw('reason, COUNT(build_id) as total'));
+    q.groupBy('reason');
+  }).fetchAll({ transacting: trx });
+
+  counters.models.forEach((row) => {
+    buildAnnotationTotal.set(
+      { metric_type: 'kpi', reason: row.get('reason') }, row.get('total'));
+  });
+}

--- a/src/server/metrics/index.js
+++ b/src/server/metrics/index.js
@@ -1,6 +1,7 @@
 import db from '../db';
-import updateGitHubUsersTotal from './github-users';
+import updateBuildAnnotationTotal from './build-annotation';
 import updateDeveloperUptake from './developer-uptake';
+import updateGitHubUsersTotal from './github-users';
 
 let existingInterval = null;
 
@@ -8,6 +9,7 @@ function updateAllMetrics() {
   return db.transaction(async (trx) => {
     await updateGitHubUsersTotal(trx);
     await updateDeveloperUptake(trx);
+    await updateBuildAnnotationTotal(trx);
   });
 }
 

--- a/test/unit/src/server/metrics/t_build-annotation.js
+++ b/test/unit/src/server/metrics/t_build-annotation.js
@@ -27,15 +27,13 @@ describe('The build Annotation metric', () => {
     return db.transaction(async (trx) => {
       for (let i = 1; i <= 2; i++) {
         const annotation = db.model('BuildAnnotation').forge({
-          build_id: i,
-          reason: BUILD_TRIGGERED_BY_POLLER
+          build_id: i, reason: BUILD_TRIGGERED_BY_POLLER
         });
         await annotation.save({}, { method: 'insert', transacting: trx });
       }
       for (let i = 3; i <= 6; i++) {
         const annotation = db.model('BuildAnnotation').forge({
-          build_id: i,
-          reason: BUILD_TRIGGERED_MANUALLY
+          build_id: i, reason: BUILD_TRIGGERED_MANUALLY
         });
         await annotation.save({}, { method: 'insert', transacting: trx });
       }
@@ -47,15 +45,14 @@ describe('The build Annotation metric', () => {
         name: metricName,
         help: 'Total number of build annotations labelled by reason.',
         values: [{
-          labels: { metric_type: 'kpi' ,
-                    reason: BUILD_TRIGGERED_BY_POLLER },
+          labels: { metric_type: 'kpi', reason: BUILD_TRIGGERED_BY_POLLER },
           value: 2
         }, {
-          labels: { metric_type: 'kpi' ,
-                    reason: BUILD_TRIGGERED_MANUALLY },
+          labels: { metric_type: 'kpi', reason: BUILD_TRIGGERED_MANUALLY },
           value: 4
         }]
       });
     });
   });
+
 });

--- a/test/unit/src/server/metrics/t_build-annotation.js
+++ b/test/unit/src/server/metrics/t_build-annotation.js
@@ -1,0 +1,61 @@
+import expect from 'expect';
+import promClient from 'prom-client';
+
+import db from '../../../../../src/server/db';
+import {
+  BUILD_TRIGGERED_MANUALLY,
+  BUILD_TRIGGERED_BY_POLLER
+} from '../../../../../src/common/helpers/build_annotation';
+
+describe('The build Annotation metric', () => {
+  let updateBuildAnnotationTotal;
+
+  beforeEach(async () => {
+    // this needs to be required in test rather then imported
+    // to make sure it registers metrics when tests are run and cleared in after hook
+    updateBuildAnnotationTotal = require(
+      '../../../../../src/server/metrics/build-annotation').default;
+
+    await db.model('BuildAnnotation').query('truncate').fetch();
+  });
+
+  afterEach(() => {
+    promClient.register.clear();
+  });
+
+  it('returns the number of rows in BuildAnnotation', () => {
+    return db.transaction(async (trx) => {
+      for (let i = 1; i <= 2; i++) {
+        const annotation = db.model('BuildAnnotation').forge({
+          build_id: i,
+          reason: BUILD_TRIGGERED_BY_POLLER
+        });
+        await annotation.save({}, { method: 'insert', transacting: trx });
+      }
+      for (let i = 3; i <= 6; i++) {
+        const annotation = db.model('BuildAnnotation').forge({
+          build_id: i,
+          reason: BUILD_TRIGGERED_MANUALLY
+        });
+        await annotation.save({}, { method: 'insert', transacting: trx });
+      }
+
+      await updateBuildAnnotationTotal(trx);
+      const metricName = 'bsi_build_annotation_total';
+      expect(promClient.register.getSingleMetric(metricName).get()).toEqual({
+        type: 'gauge',
+        name: metricName,
+        help: 'Total number of build annotations labelled by reason.',
+        values: [{
+          labels: { metric_type: 'kpi' ,
+                    reason: BUILD_TRIGGERED_BY_POLLER },
+          value: 2
+        }, {
+          labels: { metric_type: 'kpi' ,
+                    reason: BUILD_TRIGGERED_MANUALLY },
+          value: 4
+        }]
+      });
+    });
+  });
+});


### PR DESCRIPTION
E.g.`bsi_build{metric_type="kpi", reason="triggered-by-poller"}: <total>`.

