### PR TITLE
Only poll parts pointing to top-level repos.

### DIFF
--- a/src/server/scripts/poller.js
+++ b/src/server/scripts/poller.js
@@ -205,6 +205,12 @@ export class GitSourcePart {
       var sourceUrl = part['source'];
       var sourceBranch = part['source-branch'];
       var sourceTag = part['source-tag'];
+      const { url } = parseGitHubRepoUrl(sourceUrl);
+      if (sourceUrl.replace('.git', '') != url) {
+        logger.info(
+          `Not checking ${sourceUrl} as only top-level repos are supported`);
+        return;
+      }
       // TODO: figure out tag support:
       if (sourceTag) {
         logger.info(

--- a/test/unit/src/server/scripts/t_poller.js
+++ b/test/unit/src/server/scripts/t_poller.js
@@ -412,7 +412,7 @@ describe('Poller script helpers', function() {
     it('only extracts GH repos', () => {
       const snapcraft_yaml = {
         parts: {
-          'gh': {
+          'gh-full': {
             'source': 'https://github.com/foo/bar.git'
           },
           'non-gh': {
@@ -424,15 +424,15 @@ describe('Poller script helpers', function() {
           'gh-download': {
             'source': 'https://github.com/foo/bar/releases/download/release-1/a.deb'
           },
-          'gh-2': {
-            'source': 'https://github.com/foo/zoing.git'
+          'gh-short': {
+            'source': 'https://github.com/foo/zoing'
           }
         }
       };
       const parts = extractPartsToPoll(snapcraft_yaml);
       expect(parts.length).toBe(2);
       expect(parts[0].repoUrl).toEqual('https://github.com/foo/bar.git');
-      expect(parts[1].repoUrl).toEqual('https://github.com/foo/zoing.git');
+      expect(parts[1].repoUrl).toEqual('https://github.com/foo/zoing');
     });
 
   });

--- a/test/unit/src/server/scripts/t_poller.js
+++ b/test/unit/src/server/scripts/t_poller.js
@@ -421,6 +421,9 @@ describe('Poller script helpers', function() {
           'non-git': {
             'source': 'https://code.launchpad.net/foo/bar'
           },
+          'gh-download': {
+            'source': 'https://github.com/foo/bar/releases/download/release-1/a.deb'
+          },
           'gh-2': {
             'source': 'https://github.com/foo/zoing.git'
           }


### PR DESCRIPTION
## Done

Skip polling of parts specifying non top-level GH repositories as `source`, the API doesn't allow us to correctly verify changes and the vast majority of the case it's a static resource (release downloads or in-tree assets)

Fixes #1014 
