### PR TITLE
Add a trivial /_status/check endpoint

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -376,6 +376,9 @@
         }
       }
     },
+    "express-healthcheck": {
+      "version": "0.1.0"
+    },
     "express-prom-bundle": {
       "version": "2.1.0"
     },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "dotenv": "^2.0.0",
     "es6-promise": "^4.0.5",
     "express": "^4.14.0",
+    "express-healthcheck": "^0.1.0",
     "express-prom-bundle": "^2.1.0",
     "express-session": "^1.14.1",
     "express-winston": "^2.0.0",

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -3,6 +3,7 @@ import helmet from 'helmet';
 import session from 'express-session';
 import url from 'url';
 import path from 'path';
+import healthcheck from 'express-healthcheck';
 import promBundle from 'express-prom-bundle';
 import expressWinston from 'express-winston';
 import raven from 'raven';
@@ -62,6 +63,7 @@ app.use(metricsBundle);
 
 // routes
 app.use('/metrics', trustedNetworks, metricsBundle.metricsMiddleware);
+app.use('/_status/check', trustedNetworks, healthcheck());
 app.use(generateToken);
 app.use('/', routes.login);
 app.use('/api', routes.github);


### PR DESCRIPTION
This is just enough to keep the ols-http charm layer happy.  I'm not
quite sure why this suddenly started to be a problem, but it's currently
causing deployments to fail to complete.

We don't have a good way to unit-test the full server app assembly, but
I've tested this manually by pointing curl at `/_status/check`, either
from localhost or from an IP address in `TRUSTED_NETWORKS`.