### PR TITLE
Adds location to GA pageview event.

### DIFF
--- a/src/common/root.js
+++ b/src/common/root.js
@@ -18,6 +18,7 @@ export default class Root extends Component {
     */
     history.listen((location) => {
       if (window.ga) {
+        window.ga('set', 'location', window.location.href);
         window.ga('set', 'page', location.pathname);
         window.ga('send', 'pageview');
       }


### PR DESCRIPTION
## Done

Adds location to pageview GA event to possibly fix /select-repository not appearing in GA in history change.

## QA

To properly QA it we need to get it to production and run agains our GA suite.

For testing locally you would need to set up some testing GA account ids for GOOGLE_ANALYTICS_ID or  GOOGLE_OPTIMIZE_ID env variables so that GA scripts are properly loaded. (possibly using values from production.env is fine, they will not be tracked in GA from localhost anyway).
- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Open network panel in browser debug tools
- Go to "Add repos"
- Look into network panel, find request to GA, it should contain `dl` parameter set correctly to full /select-repository location

<img width="521" alt="screen shot 2017-12-06 at 14 31 08" src="https://user-images.githubusercontent.com/83575/33663941-26c7fb24-da92-11e7-93d3-b26ae9f9d414.png">



## Issue / Card

Fixes #997 
