### PR TITLE
Adds cookie notification based on Canonical cookie-policy module

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -205,6 +205,9 @@
     "cookie": {
       "version": "0.3.1"
     },
+    "cookie-policy": {
+      "version": "1.0.5"
+    },
     "cookie-signature": {
       "version": "1.0.6"
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "classnames": "^2.2.5",
     "clipboard": "^1.6.1",
     "connect-memcached": "^0.2.0",
+    "cookie-policy": "^1.0.5",
     "css-modules-require-hook": "^4.0.5",
     "dotenv": "^2.0.0",
     "es6-promise": "^4.0.5",

--- a/src/common/components/cookie-notification/index.js
+++ b/src/common/components/cookie-notification/index.js
@@ -1,0 +1,99 @@
+import React, { Component } from 'react';
+
+// importing styles directly from cookie-policy module
+import styles from '../../../../node_modules/cookie-policy/build/css/cookie-policy.css';
+
+// Quick React-friendly reimplementation of cookie-policy script:
+// https://github.com/canonical-webteam/cookie-policy/blob/master/src/js/cookie-policy.js
+// Note: it doesn't support any settings (like custom content or delay)
+export default class CookieNotification extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOpen: false
+    };
+  }
+
+  componentDidMount() {
+    this.setState({
+      isOpen: (this.getCookie('_cookies_accepted') !== 'true')
+    });
+  }
+
+  closeCookie() {
+    if (this.state.isOpen) {
+      this.setState({ isOpen: false });
+      this.setCookie('_cookies_accepted', 'true', 3000);
+    }
+  }
+
+  setCookie(name, value, exdays) {
+    var d = new Date();
+    d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000);
+    var expires = 'expires=' + d.toUTCString();
+    document.cookie = name + '=' + value + '; ' + expires;
+  }
+
+  getCookie(name) {
+    name = name + '=';
+    var ca = document.cookie.split(';');
+    for (var i = 0; i < ca.length; i++) {
+      var c = ca[i];
+      while (c.charAt(0) == ' ') {
+        c = c.substring(1);
+      }
+      if (c.indexOf(name) === 0) {
+        return c.substring(name.length, c.length);
+      }
+    }
+    return '';
+  }
+
+  onCloseClick(event) {
+    event.preventDefault();
+    this.closeCookie();
+  }
+
+  render() {
+    return !this.state.isOpen ? null : (
+      <dialog
+        tabIndex="0"
+        open="open"
+        role="alertdialog"
+        className={ styles['p-notification--cookie-policy'] }
+        aria-labelledby="cookie-policy-title"
+        aria-describedby="cookie-policy-content"
+      >
+        <h1 id="cookie-policy-title" className={ styles['u-off-screen'] }>
+          Cookie policy notification
+        </h1>
+        <p
+          className={ styles['p-notification__content'] }
+          id="cookie-policy-content"
+          role="document"
+          tabIndex="0"
+        >
+          We use cookies to improve your experience. By your continued
+          use of this site you accept such use. To change your settings
+          please
+          {' '}
+          <a
+            href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            see our policy
+          </a>.
+          <button
+            className={ styles['p-notification__close'] }
+            aria-label="Close this cookie policy notification"
+            onClick={ this.onCloseClick.bind(this) }
+          >
+            Close
+          </button>
+        </p>
+      </dialog>
+    );
+  }
+}

--- a/src/common/containers/app.js
+++ b/src/common/containers/app.js
@@ -4,6 +4,7 @@ import Helmet from 'react-helmet';
 
 import Header from '../components/header';
 import Footer from '../components/footer';
+import CookieNotification from '../components/cookie-notification';
 
 export class App extends Component {
   render() {
@@ -24,6 +25,7 @@ export class App extends Component {
         />
         { this.props.children }
         <Footer />
+        <CookieNotification />
       </div>
     );
   }


### PR DESCRIPTION
## Done

Adds a cookie policy notification to the page.
Based on `cookie-policy` (https://github.com/canonical-webteam/cookie-policy) module, but reimplemented to fit React and CSS Modules ecosystem.



## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Cookie policy notification should show up on the bottom of the screen.
- Close it by clicking on X
- Check dev tools to see if cookie `_cookies_accepted` was added.
- Reload the page (notification should not appear if you still have the cookie)
- Delete `_cookies_accepted` cookie
- Reload the page (notification should appear again)


## Issue / Card

Fixes #786

## Screenshots

<img width="1062" alt="screen shot 2017-12-08 at 13 37 44" src="https://user-images.githubusercontent.com/83575/33766742-2726f29e-dc1f-11e7-8de5-c9ae8e0c63e3.png">

