### PR TITLE
Disables self-link on build details page.

### DIFF
--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -51,7 +51,8 @@ const BuildRow = (props) => {
     statusMessage,
     dateStarted,
     reason,
-    commitId
+    commitId,
+    isLinked
   } = props;
 
   let humanDuration;
@@ -62,7 +63,7 @@ const BuildRow = (props) => {
   }
 
   // only link to builds that have log available
-  const buildUrl = buildLogUrl
+  const buildUrl = (isLinked && buildLogUrl)
     ? `/user/${repository.fullName}/${buildId}`
     : null;
 
@@ -95,6 +96,10 @@ const BuildRow = (props) => {
   );
 };
 
+BuildRow.defaultProps = {
+  isLinked: true
+};
+
 BuildRow.propTypes = {
   // params from URL
   repository: PropTypes.shape({
@@ -110,7 +115,8 @@ BuildRow.propTypes = {
   dateStarted: PropTypes.string,
   duration: PropTypes.string,
   reason: PropTypes.string,
-  commitId: PropTypes.string
+  commitId: PropTypes.string,
+  isLinked: PropTypes.bool
 };
 
 export default BuildRow;

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -101,7 +101,11 @@ class BuildDetails extends Component {
                 </Row>
               </Head>
               <Body>
-                <BuildRow repository={repository} {...build} />
+                <BuildRow
+                  repository={repository}
+                  {...build}
+                  isLinked={false} // disable link to the same build we are already looking at
+                />
               </Body>
             </Table>
             {

--- a/test/unit/src/common/components/build-row/t_build-row.js
+++ b/test/unit/src/common/components/build-row/t_build-row.js
@@ -88,6 +88,25 @@ describe('<BuildRow />', function() {
     });
   });
 
+  context('when build link is disabled', () => {
+    beforeEach(() => {
+      element = shallow(<BuildRow repository={TEST_REPO} {...TEST_BUILD} isLinked={false} />);
+    });
+
+    it('should render Row', () => {
+      expect(element.type()).toBe(Row);
+    });
+
+    it('should not contain Link to build page', () => {
+      expect(element.find(Link).length).toBe(0);
+    });
+
+    it('should contain BuildStatus not linked to build page', () => {
+      expect(element.find('BuildStatus').length).toBe(1);
+      expect(element.find('BuildStatus').prop('link')).toBe(null);
+    });
+  });
+
   context('when build log is not yet available', () => {
     beforeEach(() => {
       const buildWithoutLog = {


### PR DESCRIPTION
## Done

Added a property to allow disabling link in BuildRow component.
So now, build id number doesn't unnecessary link to itself on build details page.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to any build details page
- Build id should not be linked


## Issue / Card

Fixes #350 

## Screenshots

<img width="1060" alt="screen shot 2017-12-13 at 16 23 55" src="https://user-images.githubusercontent.com/83575/33949626-0d97e9da-e022-11e7-9b3d-7622a886039a.png">

