### PR TITLE
Fixes checking snapcraft data errors for first time flow.

### DIFF
--- a/src/common/selectors/index.js
+++ b/src/common/selectors/index.js
@@ -43,7 +43,7 @@ export const hasNoRegisteredNames = createSelector(
 export const hasNoConfiguredSnaps = createSelector(
   [getSnapsIndex, getSnaps],
   (ids, snaps) => {
-    return !ids.some((id) => snaps[id].snapcraftData);
+    return !ids.some((id) => snaps[id].snapcraftData && !snaps[id].snapcraftData.error);
   }
 );
 
@@ -122,7 +122,7 @@ export const snapsWithRegisteredNameAndSnapcraftData = createSelector(
   [getSnapsIndex, getSnaps],
   (ids, snaps) => {
     return ids.map((id) => snaps[id]).filter((snap) => {
-      return snap.storeName && snap.snapcraftData;
+      return snap.storeName && snap.snapcraftData && !snap.snapcraftData.error;
     });
   }
 );
@@ -134,7 +134,7 @@ export const snapsWithRegisteredNameAndNoSnapcraftData = createSelector(
   [getSnapsIndex, getSnaps],
   (ids, snaps) => {
     return ids.map((id) => snaps[id]).filter((snap) => {
-      return snap.storeName && !snap.snapcraftData;
+      return snap.storeName && (!snap.snapcraftData || snap.snapcraftData.error);
     });
   }
 );

--- a/test/unit/src/common/selectors/t_selectors.js
+++ b/test/unit/src/common/selectors/t_selectors.js
@@ -69,6 +69,21 @@ describe('selectors', function() {
     }
   };
 
+  const stateWithSnapcraftDataError = {
+    snaps: {
+      ids: ['https:github.com/anowner/aname']
+    },
+    entities: {
+      snaps: {
+        'https:github.com/anowner/aname': {
+          storeName: 'bsi-test-ii',
+          snapcraftData: { error: 'Some error' },
+          gitRepoUrl: 'https:github.com/anowner/aname'
+        }
+      }
+    }
+  };
+
   context('hasSnaps', function() {
     it('should be false when no snaps in state', function() {
       expect(hasSnaps(stateWithNoSnaps)).toBe(false);
@@ -112,6 +127,10 @@ describe('selectors', function() {
       expect(hasNoConfiguredSnaps(stateWithNoName)).toBe(true);
     });
 
+    it('should be true when error snapcraft data in state', function() {
+      expect(hasNoConfiguredSnaps(stateWithSnapcraftDataError)).toBe(true);
+    });
+
     it('should be false when snapcraft data is in state', function() {
       expect(hasNoConfiguredSnaps(stateWithSnapcraftData)).toBe(false);
     });
@@ -147,16 +166,21 @@ describe('selectors', function() {
       snaps: {
         ids: [
           'https:github.com/anowner/aname',
-          'https:github.com/anowner/aname-i'
+          'https:github.com/anowner/aname-i',
+          'https:github.com/anowner/aname-ii'
         ]
       },
       entities: {
         snaps: {
           'https:github.com/anowner/aname': {
-            storeName: 'bsi-test-ii',
-            snapcraftData: { name: 'bsi-test-ii' }
+            storeName: 'bsi-test',
+            snapcraftData: { name: 'bsi-test' }
           },
-          'https:github.com/anowner/aname-i': {}
+          'https:github.com/anowner/aname-i': {},
+          'https:github.com/anowner/aname-ii': {
+            storeName: 'bsi-test-ii',
+            snapcraftData: { error: 'Some error' }
+          }
         }
       }
     };
@@ -169,8 +193,17 @@ describe('selectors', function() {
       const snaps = snapsWithRegisteredNameAndSnapcraftData(stateWithNameAndSnapcraftData);
       expect(snaps.length).toBe(1);
       expect(snaps).toInclude({
+        storeName: 'bsi-test',
+        snapcraftData: { name: 'bsi-test' }
+      });
+    });
+
+    it('should not include snap with error in snapcraft data', function() {
+      const snaps = snapsWithRegisteredNameAndSnapcraftData(stateWithNameAndSnapcraftData);
+      expect(snaps.length).toBe(1);
+      expect(snaps).toNotInclude({
         storeName: 'bsi-test-ii',
-        snapcraftData: { name: 'bsi-test-ii' }
+        snapcraftData: { error: 'Some error' }
       });
     });
   });
@@ -179,18 +212,23 @@ describe('selectors', function() {
     const stateWithNameAndNoSnapcraftData = {
       snaps: {
         ids: [
-          'https:github.com/anowner/aname',
-          'https:github.com/anowner/aname-i'
+          'https://github.com/anowner/aname',
+          'https://github.com/anowner/aname-i',
+          'https://github.com/anowner/aname-ii'
         ]
       },
       entities: {
         snaps: {
-          'https:github.com/anowner/aname': {
-            storeName: 'bsi-test-ii',
-            snapcraftData: { name: 'bsi-test-ii' }
+          'https://github.com/anowner/aname': {
+            storeName: 'bsi-test',
+            snapcraftData: { name: 'bsi-test' }
           },
-          'https:github.com/anowner/aname-i': {
-            storeName: 'bsi-test-iii'
+          'https://github.com/anowner/aname-i': {
+            storeName: 'bsi-test-i'
+          },
+          'https://github.com/anowner/aname-ii': {
+            storeName: 'bsi-test-ii',
+            snapcraftData: { error: 'Some error' }
           }
         }
       }
@@ -202,9 +240,18 @@ describe('selectors', function() {
 
     it('should include snap with name and no snapcraft data', function() {
       const snaps = snapsWithRegisteredNameAndNoSnapcraftData(stateWithNameAndNoSnapcraftData);
-      expect(snaps.length).toBe(1);
+      expect(snaps.length).toBe(2);
       expect(snaps).toInclude({
-        storeName: 'bsi-test-iii'
+        storeName: 'bsi-test-i'
+      });
+    });
+
+    it('should include snap with name and error snapcraft data', function() {
+      const snaps = snapsWithRegisteredNameAndNoSnapcraftData(stateWithNameAndNoSnapcraftData);
+      expect(snaps.length).toBe(2);
+      expect(snaps).toInclude({
+        storeName: 'bsi-test-ii',
+        snapcraftData: { error: 'Some error' }
       });
     });
   });

--- a/test/unit/src/common/selectors/t_selectors.js
+++ b/test/unit/src/common/selectors/t_selectors.js
@@ -26,15 +26,15 @@ describe('selectors', function() {
 
   const stateWithNoName = {
     snaps: {
-      ids: ['https:github.com/anowner/aname', 'https:github.com/anowner/aname-i']
+      ids: ['https://github.com/anowner/aname', 'https://github.com/anowner/aname-i']
     },
     entities: {
       snaps: {
-        'https:github.com/anowner/aname': {
-          gitRepoUrl: 'https:github.com/anowner/aname'
+        'https://github.com/anowner/aname': {
+          gitRepoUrl: 'https://github.com/anowner/aname'
         },
-        'https:github.com/anowner/aname-i': {
-          gitRepoUrl: 'https:github.com/anowner/aname-i'
+        'https://github.com/anowner/aname-i': {
+          gitRepoUrl: 'https://github.com/anowner/aname-i'
         }
       }
     }
@@ -42,13 +42,13 @@ describe('selectors', function() {
 
   const stateWithName = {
     snaps: {
-      ids: ['https:github.com/anowner/aname']
+      ids: ['https://github.com/anowner/aname']
     },
     entities: {
       snaps: {
-        'https:github.com/anowner/aname': {
+        'https://github.com/anowner/aname': {
           storeName: 'bsi-test-ii',
-          gitRepoUrl: 'https:github.com/anowner/aname'
+          gitRepoUrl: 'https://github.com/anowner/aname'
         }
       }
     }
@@ -56,14 +56,14 @@ describe('selectors', function() {
 
   const stateWithSnapcraftData = {
     snaps: {
-      ids: ['https:github.com/anowner/aname']
+      ids: ['https://github.com/anowner/aname']
     },
     entities: {
       snaps: {
-        'https:github.com/anowner/aname': {
+        'https://github.com/anowner/aname': {
           storeName: 'bsi-test-ii',
           snapcraftData: { name: 'bsi-test-ii' },
-          gitRepoUrl: 'https:github.com/anowner/aname'
+          gitRepoUrl: 'https://github.com/anowner/aname'
         }
       }
     }
@@ -71,14 +71,14 @@ describe('selectors', function() {
 
   const stateWithSnapcraftDataError = {
     snaps: {
-      ids: ['https:github.com/anowner/aname']
+      ids: ['https://github.com/anowner/aname']
     },
     entities: {
       snaps: {
-        'https:github.com/anowner/aname': {
+        'https://github.com/anowner/aname': {
           storeName: 'bsi-test-ii',
           snapcraftData: { error: 'Some error' },
-          gitRepoUrl: 'https:github.com/anowner/aname'
+          gitRepoUrl: 'https://github.com/anowner/aname'
         }
       }
     }
@@ -165,19 +165,19 @@ describe('selectors', function() {
     const stateWithNameAndSnapcraftData = {
       snaps: {
         ids: [
-          'https:github.com/anowner/aname',
-          'https:github.com/anowner/aname-i',
-          'https:github.com/anowner/aname-ii'
+          'https://github.com/anowner/aname',
+          'https://github.com/anowner/aname-i',
+          'https://github.com/anowner/aname-ii'
         ]
       },
       entities: {
         snaps: {
-          'https:github.com/anowner/aname': {
+          'https://github.com/anowner/aname': {
             storeName: 'bsi-test',
             snapcraftData: { name: 'bsi-test' }
           },
-          'https:github.com/anowner/aname-i': {},
-          'https:github.com/anowner/aname-ii': {
+          'https://github.com/anowner/aname-i': {},
+          'https://github.com/anowner/aname-ii': {
             storeName: 'bsi-test-ii',
             snapcraftData: { error: 'Some error' }
           }


### PR DESCRIPTION
## Done

Fixes checking for snapcraft.yaml data errors to properly detect not configured repos.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Remove all the repositories
- Add one repository without snapcraft.yaml.
- Register a name for this repo.
- First steps heading on the top should ask for creating snapcraft.yaml and "Not configured" dropdown should be open for this repo (see screenshot below)


## Issue / Card

Fixes #1010 

## Screenshots

<img width="1099" alt="screen shot 2017-12-14 at 10 46 02" src="https://user-images.githubusercontent.com/83575/33988342-055ab44c-e0bc-11e7-8b4a-6b6162b40e71.png">

