### PR TITLE
Updates install instructions for snapcraft

### DIFF
--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -39,7 +39,7 @@ class BuildDetails extends Component {
           <HelpInstallSnap headline='To debug this build:'>
             sudo snap install lxd && sudo lxd init # if you don’t have LXD already<br/>
             sudo usermod -a -G lxd $USER && newgrp lxd # if your user is not in the lxd group already<br/>
-            sudo snap install --classic --edge snapcraft # if you don’t have snapcraft already<br/>
+            sudo snap install --classic snapcraft # if you don’t have snapcraft already<br/>
             <br/>
             git clone {repository.url}<br/>
             cd {repository.name}<br/>


### PR DESCRIPTION
## Done

Removed `--edge` from snapcraft install instruction when build fails, as snapcraft is now available in stable channel.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to a build details page of failed build
- See install instructions


## Issue / Card

Fixes #1028

## Screenshots

<img width="1049" alt="screen shot 2017-12-18 at 15 02 55" src="https://user-images.githubusercontent.com/83575/34109845-26f19818-e405-11e7-9b9e-d7d57e8b1a85.png">
