### PR TITLE
Adds a column to db to store public user email.

### DIFF
--- a/migrations/20171219153812_user-email.js
+++ b/migrations/20171219153812_user-email.js
@@ -1,0 +1,15 @@
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('github_user', function(table) {
+      table.text('email');
+    })
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('github_user', function(table) {
+      table.dropColumn('email');
+    })
+  ]);
+};

--- a/src/server/db/models/github-user.js
+++ b/src/server/db/models/github-user.js
@@ -4,6 +4,7 @@ export default function register(db) {
    *   github_id: ID from GitHub
    *   name: display name from GitHub
    *   login: login name from GitHub
+   *   email: public email from GitHub
    *   created_at: creation date
    *   updated_at: update date
    *   last_login_at: last login date

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -95,6 +95,7 @@ export const verify = (req, res, next) => {
         }
         await dbUser.set({
           name: userResponse.body.name || null,
+          email: userResponse.body.email || null,
           login: userResponse.body.login,
           last_login_at: new Date()
         });

--- a/test/routes/src/server/routes/t_github-auth.js
+++ b/test/routes/src/server/routes/t_github-auth.js
@@ -138,7 +138,7 @@ describe('The login route', () => {
         beforeEach(async () => {
           ghApi = nock(conf.get('GITHUB_API_ENDPOINT'))
             .get('/user')
-            .reply(200, { id: 123, login: 'anowner' })
+            .reply(200, { id: 123, login: 'anowner', email: 'test@email.com' })
             .get('/user/orgs')
             .reply(200, [{ login: 'org2' }]);
           setupInMemoryMemcached();
@@ -181,7 +181,8 @@ describe('The login route', () => {
             .fetch();
           expect(dbUser.serialize()).toMatch({
             github_id: 123,
-            login: 'anowner'
+            login: 'anowner',
+            email: 'test@email.com'
           });
         });
 


### PR DESCRIPTION
## Done

Added email column to github_user database table.
Saving public user email from GitHub when user signs in.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Make sure you have public email in your GH profile
- Sign in to BSI
- Your public email should be stored in db


## Issue / Card

Fixes #731

