### PR TITLE
Update the copyright year

### DIFF
--- a/src/common/components/footer/index.js
+++ b/src/common/components/footer/index.js
@@ -24,7 +24,7 @@ export default class Footer extends Component {
               </li>
             </ul>
           </div>
-          <p className={ styles.copyright }>© 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+          <p className={ styles.copyright }>© 2017-2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
           <p><a href="https://www.ubuntu.com/legal">Legal information</a> · <a href="https://github.com/canonical-websites/build.snapcraft.io/issues/new">Report a bug on this site</a></p>
         </div>
       </div>


### PR DESCRIPTION
## Done

I updated the copyright year of the footer.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- [List additional steps to QA the new features or prove the bug has been resolved]
