### PR TITLE
Removes non-functional “Sign out” item

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -47,9 +47,6 @@ export default class Header extends Component {
                   <li className={ style['p-navigation__item'] } role="menuitem">
                     <a>Hi, {user.name || user.login}</a>
                   </li>
-                  <li className={ style['p-navigation__link'] } role="menuitem">
-                    <a href="/auth/logout">Sign out</a>
-                  </li>
                 </ul>
               :
                 <ul className={ style['p-navigation__links--right']} role="menu">

--- a/test/unit/src/common/components/header/t_header.js
+++ b/test/unit/src/common/components/header/t_header.js
@@ -39,10 +39,6 @@ describe('<Header />', function() {
       expect(element.html().indexOf('Hi, Joe Doe')).toBeGreaterThan(0);
     });
 
-    it('should render sign out link', () => {
-      expect(element.containsMatchingElement(<a>Sign out</a>)).toBe(true);
-    });
-
     context('when user has no name', () => {
       const user = {
         login: 'jdoe'


### PR DESCRIPTION
## Done

Removes the “Sign out” item from the header. A temporary solution, until proper sign-in and sign-out is implemented when build.snapcraft.io is integrated with the rest of snapcraft.io.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- sign in
- verify that in the header, “Hi, {your name}” is no longer followed by “Sign out”

## Issue / Card

Fixes #305.