### PR TITLE
Updates nock to latest version and updates tests to parsed POST body

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "file-loader": "^0.9.0",
     "flux-standard-action": "^1.0.0",
     "mocha": "^3.1.2",
-    "nock": "^9.0.2",
+    "nock": "^9.2.2",
     "node-sass": "^4.5.3",
     "nyc": "^9.0.1",
     "postcss-loader": "^1.0.0",

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -103,7 +103,7 @@ describe('The Launchpad API endpoint', () => {
         beforeEach(() => {
           const lp_api_url = conf.get('LP_API_URL');
           nock(lp_api_url)
-            .post('/devel/+snaps', (body) => tmatch(body, { 'ws.op': 'new' }))
+            .post('/devel/+snaps', (body) => tmatch(body, { ws: { op: 'new' } }))
             .reply(
               400,
               'There is already a snap package with the same name and owner.');
@@ -161,7 +161,7 @@ describe('The Launchpad API endpoint', () => {
           lpApi = nock(lp_api_url);
           lpApi
             .post('/devel/+snaps', (body) => tmatch(body, {
-              'ws.op': 'new',
+              ws: { op: 'new' },
               git_repository_url: 'https://github.com/anowner/aname',
               auto_build: 'false',
               processors: [
@@ -185,7 +185,7 @@ describe('The Launchpad API endpoint', () => {
           hmac.update('aname');
           lpApi
             .post(`/devel/~test-user/+snap/${snapName}`, {
-              'ws.op': 'newWebhook',
+              ws: { op: 'newWebhook' },
               delivery_url: `${conf.get('BASE_URL')}/anowner/aname/` +
                             'webhook/notify',
               event_types: 'snap:build:0.1',
@@ -557,7 +557,7 @@ describe('The Launchpad API endpoint', () => {
         hmac.update('test-snap');
         lpApi
           .post('/devel/~another-user/+snap/test-snap', {
-            'ws.op': 'newWebhook',
+            ws: { op: 'newWebhook' },
             delivery_url: `${conf.get('BASE_URL')}/anowner/test-snap/` +
                           'webhook/notify',
             event_types: 'snap:build:0.1',
@@ -1398,7 +1398,7 @@ describe('The Launchpad API endpoint', () => {
               });
             lpScope
               .post('/devel/~test-user/+snap/test-snap', {
-                'ws.op': 'completeAuthorization',
+                ws: { op: 'completeAuthorization' },
                 'root_macaroon': 'dummy-macaroon'
               })
               .reply(200, 'null', {
@@ -1879,7 +1879,7 @@ describe('The Launchpad API endpoint', () => {
           .reply(200, { permissions: { admin: true } });
         api = nock(lp_api_url);
         api.post(`/devel${lp_snap_path}`, {
-          'ws.op': 'requestAutoBuilds'
+          ws: { op: 'requestAutoBuilds' }
         })
           .reply(200, [
             {

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -22,7 +22,7 @@ describe('The WebHook API endpoint', () => {
   beforeEach(async () => {
     await db.model('BuildAnnotation').query().truncate();
   });
-  
+
   afterEach(() => {
     nock.cleanAll();
   });
@@ -160,7 +160,7 @@ describe('The WebHook API endpoint', () => {
               ]
             });
           requestAutoBuilds = nock(lp_api_url)
-            .post(`/devel${lp_snap_path}`, { 'ws.op': 'requestAutoBuilds' })
+            .post(`/devel${lp_snap_path}`, { ws: { op: 'requestAutoBuilds' } })
             .reply(200, [
               {
                 resource_type_link: `${lp_api_base}/#snap_build`,
@@ -306,7 +306,7 @@ describe('The WebHook API endpoint', () => {
                 auto_build: true
               });
             requestAutoBuilds = nock(lp_api_url)
-              .post(`/devel${lp_snap_path}`, { 'ws.op': 'requestAutoBuilds' })
+              .post(`/devel${lp_snap_path}`, { ws: { op: 'requestAutoBuilds' } })
               .reply(200, [
                 {
                   resource_type_link: `${lp_api_base}/#snap_build`,

--- a/test/unit/src/server/launchpad/t_client.js
+++ b/test/unit/src/server/launchpad/t_client.js
@@ -103,7 +103,7 @@ describe('Launchpad', () => {
 
   describe('named_post', () => {
     it('handles successful response', async () => {
-      lp.post('/devel/people', { 'ws.op': 'newTeam' })
+      lp.post('/devel/people', { 'ws' : { 'op': 'newTeam' } })
         .matchHeader('Authorization', checkAuthorization)
         .reply(200, { entry: { resource_type_link: 'foo' } });
 
@@ -113,7 +113,7 @@ describe('Launchpad', () => {
     });
 
     it('handles factory response', async () => {
-      lp.post('/devel/people', { 'ws.op': 'newTeam', 'name': 'foo' })
+      lp.post('/devel/people', { 'ws': { 'op': 'newTeam' }, 'name': 'foo' })
         .matchHeader('Authorization', checkAuthorization)
         .reply(201, '', { 'Location': `${LP_API_URL}/devel/~foo` });
       lp.get('/devel/~foo')


### PR DESCRIPTION
## Done

Due to recent breaking changes in nock this updates nock to latest version and updates the tests so they don't break on travis anymore.

Fixes #1063 

## QA

- Check out this feature branch
- Run npm i
- Latest version of nock should be installed (9.2.2)
- Run npm test
- Tests should pass
