### PR TITLE
Fixes centering of first time heading

### DIFF
--- a/src/common/components/first-time-heading/firstTimeHeading.css
+++ b/src/common/components/first-time-heading/firstTimeHeading.css
@@ -2,3 +2,7 @@
   text-align: center;
   padding: 2em 0;
 }
+
+.firstTimeHeading h3 {
+  max-width: 100%;
+}

--- a/src/common/components/traffic-lights/traffic-light.css
+++ b/src/common/components/traffic-lights/traffic-light.css
@@ -3,6 +3,7 @@ $signal-colour-default: $light-grey;
 .trafficlight {
   display: flex;
   margin:1rem auto;
+  overflow: hidden;
 }
 
 .signal {


### PR DESCRIPTION
## Done

Fixes some small regression text positioning bug (after implementing max-width for headings and paragraphs).

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Have only one repo that is not configured yet (to see first time heading)
- Text in first time heading should be centered


## Screenshots

Current (this text should be centered):
<img width="1102" alt="screen shot 2018-03-05 at 13 51 32" src="https://user-images.githubusercontent.com/83575/36977826-cc68c000-2082-11e8-9e8d-3820cb9279a1.png">

Fixed (properly centered):
<img width="1060" alt="screen shot 2018-03-05 at 14 40 22" src="https://user-images.githubusercontent.com/83575/36977943-3073106e-2083-11e8-95b6-dd91fd950904.png">

