### PR TITLE
Fixes dark hover on mobile navigation

### DIFF
--- a/src/common/style/vanilla/css/navigation.css
+++ b/src/common/style/vanilla/css/navigation.css
@@ -484,13 +484,14 @@
 .p-navigation .p-navigation__image {
   display: block; }
 
-.p-navigation .p-navigation__links .p-navigation__link, .p-navigation .p-navigation__links--right .p-navigation__link, .p-navigation .p-navigation__links .p-navigation__item, .p-navigation .p-navigation__links--right .p-navigation__item {
-  border-left: 1px solid #585858; }
-  .p-navigation .p-navigation__links .p-navigation__link a:hover, .p-navigation .p-navigation__links--right .p-navigation__link a:hover, .p-navigation .p-navigation__links .p-navigation__item a:hover, .p-navigation .p-navigation__links--right .p-navigation__item a:hover,
-  .p-navigation .p-navigation__links .p-navigation__link .is-selected, .p-navigation .p-navigation__links--right .p-navigation__link .is-selected, .p-navigation .p-navigation__links .p-navigation__item .is-selected, .p-navigation .p-navigation__links--right .p-navigation__item .is-selected {
-    background: #111111; }
-  .p-navigation .p-navigation__links .p-navigation__link:last-of-type, .p-navigation .p-navigation__links--right .p-navigation__link:last-of-type, .p-navigation .p-navigation__links .p-navigation__item:last-of-type, .p-navigation .p-navigation__links--right .p-navigation__item:last-of-type {
-    border-right: 1px solid #585858; }
+@media (min-width: 769px) {
+  .p-navigation .p-navigation__links .p-navigation__link, .p-navigation .p-navigation__links--right .p-navigation__link, .p-navigation .p-navigation__links .p-navigation__item, .p-navigation .p-navigation__links--right .p-navigation__item {
+    border-left: 1px solid #585858; }
+    .p-navigation .p-navigation__links .p-navigation__link a:hover, .p-navigation .p-navigation__links--right .p-navigation__link a:hover, .p-navigation .p-navigation__links .p-navigation__item a:hover, .p-navigation .p-navigation__links--right .p-navigation__item a:hover,
+    .p-navigation .p-navigation__links .p-navigation__link .is-selected, .p-navigation .p-navigation__links--right .p-navigation__link .is-selected, .p-navigation .p-navigation__links .p-navigation__item .is-selected, .p-navigation .p-navigation__links--right .p-navigation__item .is-selected {
+      background: #111111; }
+    .p-navigation .p-navigation__links .p-navigation__link:last-of-type, .p-navigation .p-navigation__links--right .p-navigation__link:last-of-type, .p-navigation .p-navigation__links .p-navigation__item:last-of-type, .p-navigation .p-navigation__links--right .p-navigation__item:last-of-type {
+      border-right: 1px solid #585858; } }
 
 .p-navigation .p-navigation__links .p-navigation__item, .p-navigation .p-navigation__links--right .p-navigation__item {
   border-left: none;

--- a/src/common/style/vanilla/navigation.scss
+++ b/src/common/style/vanilla/navigation.scss
@@ -20,22 +20,23 @@ $color-navigation-background: #252525;
     display: block;
   }
 
-  .p-navigation__links {
-    // custom hover styles
-    .p-navigation__link {
-      border-left: 1px solid $navigation-border-color;
+    .p-navigation__links {
+      // custom hover styles
+      @media (min-width: $breakpoint-navigation-threshold + 1) {
+      .p-navigation__link {
+        border-left: 1px solid $navigation-border-color;
 
-      a:hover,
-      .is-selected {
-        background: $navigation-hover-color;
+        a:hover,
+        .is-selected {
+          background: $navigation-hover-color;
+        }
+
+        &:last-of-type {
+          border-right: 1px solid $navigation-border-color;
+        }
+
       }
-
-      &:last-of-type {
-        border-right: 1px solid $navigation-border-color;
-      }
-
     }
-
 
 
     // custom navigation non-link item for user name
@@ -65,7 +66,7 @@ $color-navigation-background: #252525;
     }
   }
 
-  @media (min-width: 769px) {
+  @media (min-width: $breakpoint-navigation-threshold + 1) {
     .p-navigation__links--right {
       margin-left: auto; // alight to right in flexbox parent
     }


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/406

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Make window small (for mobile navigation)
- Open menu
- Hover on any item, there there should be no black hover on navigation
