### PR TITLE
Highlights 'Build' link in the navigation

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -29,7 +29,7 @@ export default class Header extends Component {
                 <a href="https://snapcraft.io/store/">Store</a>
               </li>
               <li className={ style['p-navigation__link'] } role="menuitem">
-                <a href="/">Build</a>
+                <a className={ style['is-selected'] } href="/">Build</a>
               </li>
               <li className={ style['p-navigation__link'] } role="menuitem">
                 <a className={ style['p-link--external'] } href="https://dashboard.snapcraft.io/snaps">My snaps</a>


### PR DESCRIPTION
## Done

Properly highlight 'Build' link in navigation as selected

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Make sure 'Build' is selected in navigation (wherever you are in BSI)


## Issue / Card

Fixes #1075

## Screenshots

<img width="1039" alt="screen shot 2018-03-16 at 14 58 18" src="https://user-images.githubusercontent.com/83575/37524571-83440dd4-292a-11e8-9077-d03004046d68.png">

