### PR TITLE
Add arm64 builds

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -35,7 +35,7 @@ import { getSnapcraftYamlCacheId } from './github';
 // configurable.
 const DISTRIBUTION = 'ubuntu';
 const DISTRO_SERIES = 'xenial';
-const ARCHITECTURES = ['amd64', 'armhf', 'i386'];
+const ARCHITECTURES = ['amd64', 'arm64', 'armhf', 'i386'];
 
 const RESPONSE_NOT_LOGGED_IN = {
   status: 'error',

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -166,6 +166,7 @@ describe('The Launchpad API endpoint', () => {
               auto_build: 'false',
               processors: [
                 '/+processors/amd64',
+                '/+processors/arm64',
                 '/+processors/armhf',
                 '/+processors/i386'
               ]


### PR DESCRIPTION
The team providing a CLI for a popular public cloud is producing a snap and needs to build on arm64. They would like to use build.snapcraft.io for this.

This branch adds arm64 to the default set but does not back-populate configured repos to build for arm64.