### PR TITLE
Update bugtracking links in footer

### DIFF
--- a/src/common/components/footer/index.js
+++ b/src/common/components/footer/index.js
@@ -34,12 +34,12 @@ export default class Footer extends Component {
               {' '}
               <a
                 className={ style['p-link--external'] }
-                href="https://bugs.launchpad.net/snappy"
+                href="https://bugs.launchpad.net/snapd"
               >snapd</a>,
               {' '}
               <a
                 className={ style['p-link--external'] }
-                href="https://github.com/snapcore/snapcraft/issues"
+                href="https://bugs.launchpad.net/snapcraft"
               >Snapcraft</a>,
               {' '}
               or


### PR DESCRIPTION
## Done

Update snapd and snapcraft bugtracking links in footer to correctly point to launchpad

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Check if footer links to snapd and snapcraft correctly link to launchpad bugs


## Issue / Card

Fixes #1078 

