### PR TITLE
Link 'My snaps' to new account snaps page

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -32,7 +32,7 @@ export default class Header extends Component {
                 <a className={ style['is-selected'] } href="/">Build</a>
               </li>
               <li className={ style['p-navigation__link'] } role="menuitem">
-                <a className={ style['p-link--external'] } href="https://dashboard.snapcraft.io/snaps">My snaps</a>
+                <a href="https://snapcraft.io/account/snaps">My snaps</a>
               </li>
               <li className={ style['p-navigation__link'] } role="menuitem">
                 <a href="https://docs.snapcraft.io">Docs</a>


### PR DESCRIPTION
## Done

Update the 'My snaps' link in header to new account snap page (same as on snapcraft.io)

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- 'My snaps' link in header should not have external icon
- 'My snaps' link in header should link to snapcraft.io/account/snaps


## Issue / Card

Fixes #1073 

## Screenshots

<img width="1047" alt="screen shot 2018-04-30 at 07 19 06" src="https://user-images.githubusercontent.com/83575/39415722-269a5cba-4c47-11e8-90d4-3ab2684adeb3.png">
<img width="1074" alt="screen shot 2018-04-30 at 07 19 23" src="https://user-images.githubusercontent.com/83575/39415723-26b484b4-4c47-11e8-8387-2cdccc4637ff.png">

