### PR TITLE
Styles header “Forum” link as external

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -38,8 +38,7 @@ export default class Header extends Component {
                 <a href="https://docs.snapcraft.io">Docs</a>
               </li>
               <li className={ style['p-navigation__link'] } role="menuitem">
-                <a className={ style['p-link--external'] }
-                href="https://forum.snapcraft.io/categories">Forum</a>
+                <a className={ style['p-link--external'] } href="https://forum.snapcraft.io/categories">Forum</a>
               </li>
             </ul>
             { authenticated

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -38,7 +38,8 @@ export default class Header extends Component {
                 <a href="https://docs.snapcraft.io">Docs</a>
               </li>
               <li className={ style['p-navigation__link'] } role="menuitem">
-                <a href="https://forum.snapcraft.io/categories">Forum</a>
+                <a className={ style['p-link--external'] }
+                href="https://forum.snapcraft.io/categories">Forum</a>
               </li>
             </ul>
             { authenticated


### PR DESCRIPTION
Styles the “Forum” link in the header as external, since the Forum is presented as a separate site (different header navigation, different colour scheme, different sign-in sessions, etc).

The build.snapcraft.io aspect of [snapcraft.io#522](https://github.com/canonical-websites/snapcraft.io/issues/522).