### PR TITLE
Reduce polling frequency for repos

### DIFF
--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -12,7 +12,7 @@ import RepositoriesList from '../repositories-list';
 import styles from './repositories-home.css';
 
 let interval;
-const SNAP_POLL_PERIOD = (15 * 1000);
+const SNAP_POLL_PERIOD = (30 * 1000);
 
 class RepositoriesHome extends Component {
 

--- a/test/unit/src/common/components/repositories-home/t_repositories-home.js
+++ b/test/unit/src/common/components/repositories-home/t_repositories-home.js
@@ -81,10 +81,10 @@ describe('The RepositoriesHome component', () => {
         expect(props.updateSnaps).toHaveBeenCalled();
       });
 
-      context('and after fifteen seconds', () => {
+      context('and after thirty seconds', () => {
         beforeEach(() => {
           props.updateSnaps.reset();
-          clock.tick(15000);
+          clock.tick(30000);
         });
 
         it('should dispatch updateSnaps callback again', () => {


### PR DESCRIPTION
## Done

Polling repo's happens every 15 seconds, this reduces that frequency in an attempt to alleviate some issues caused by long repo lists.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Make sure the app doesn't blow up after an hour or so.

