### PR TITLE
Don't poll when page is inactive

### DIFF
--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -36,7 +36,7 @@ export class Builds extends Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const { url } = this.props.repository;
     const { snap } = this.props;
 

--- a/test/unit/src/common/components/repositories-home/t_repositories-home.js
+++ b/test/unit/src/common/components/repositories-home/t_repositories-home.js
@@ -65,12 +65,23 @@ describe('The RepositoriesHome component', () => {
         router: {}
       };
 
+      // mock document for global DOM do work in tests
+      global.document = {
+        visibilityState: 'visible',
+        addEventListener: expect.createSpy(),
+        removeEventListener: expect.createSpy()
+      };
+
       wrapper = shallow(<RepositoriesHome { ...props } />);
+    });
+
+    afterEach(() => {
+      delete global.document;
     });
 
     context('and component mounts', () => {
       beforeEach(() => {
-        wrapper.instance().componentWillMount();
+        wrapper.instance().componentDidMount();
       });
 
       afterEach(() => {
@@ -95,7 +106,7 @@ describe('The RepositoriesHome component', () => {
 
     context('and component mounts, then unmounts', () => {
       beforeEach(() => {
-        wrapper.instance().componentWillMount();
+        wrapper.instance().componentDidMount();
         clock.tick(60000);
         wrapper.instance().componentWillUnmount();
         props.updateSnaps.reset();


### PR DESCRIPTION
## Done

Disables polling for snaps and builds when page is inactive (tab is invisible).

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to My repos page
- Open "Network" panel of developer tools
- when page is visible every 30 seconds there should be requests for snaps and builds
- Switch to another tab, wait for more then 30 seconds (more then minute ideally)
- Switch back to 'My repos'
- Immediately when page is made visible snaps and builds should be fetched
- If you wait with page visible every 30 seconds there should be requests
- Switch to another tab and go back to 'My repos' quickly (in less then 30 seconds)
- There should be no requests until full 30 seconds pass

Similar on repo builds page:
- go to builds page for single repo
- when page is visible there should be a request for build statuses every 15 seconds
- if page is invisible there should be no requests in the background
- when page is visible again there should immediately be request to update builds (but only if more then 15 seconds has passed).


## Issue / Card

Part of fixes around #1090 

