### PR TITLE
Better handling of CSRF tokens in session

### DIFF
--- a/src/server/middleware/csrf-token.js
+++ b/src/server/middleware/csrf-token.js
@@ -13,8 +13,9 @@ export const generateToken = (req, res, next) => {
 
   req.session.csrfTokens.push(csrfToken);
 
-  // Only 5 valid CSRF tokens at a time. Safe to increase number.
-  while (req.session.csrfTokens.length > 5) {
+  // 100 valid CSRF tokens at a time
+  // (so multiple tabs/requests can be handled at the same time)
+  while (req.session.csrfTokens.length > 100) {
     req.session.csrfTokens.shift();
   }
 

--- a/src/server/routes/github.js
+++ b/src/server/routes/github.js
@@ -20,7 +20,6 @@ router.use('/github/user', json());
 router.get('/github/user', getUser);
 
 router.use('/github/orgs', json());
-router.get('/github/orgs', verifyToken);
 router.get('/github/orgs', refreshOrganizations);
 
 router.use('/github/repos', json());

--- a/src/server/routes/launchpad.js
+++ b/src/server/routes/launchpad.js
@@ -20,14 +20,12 @@ router.post('/launchpad/snaps', newSnap);
 router.get('/launchpad/snaps', findSnap);
 
 router.use('/launchpad/snaps/list', json());
-router.use('/launchpad/snaps/list', verifyToken);
 router.get('/launchpad/snaps/list', findSnaps);
 
 router.use('/launchpad/snaps/authorize', json());
 router.post('/launchpad/snaps/authorize', authorizeSnap);
 
 router.use('/launchpad/builds', json());
-router.use('/launchpad/builds', verifyToken);
 router.get('/launchpad/builds', getSnapBuilds);
 
 router.use('/launchpad/snaps/request-builds', json());


### PR DESCRIPTION
## Done

- removed verification of CSRF tokens from public `GET` API requests
- increased number of tokens stored in the session to allow multiple tabs opened at once

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to 'My repos'
- Open more then 10 tabs with BSI (My repos and different repos pages)
- All open tabs should work as expected, there should be no 'Unauthorized' errors when navigating around these tabs or when builds statuses are polled


## Issue / Card

Part of #1003
