### PR TITLE
Detect expired session

### DIFF
--- a/src/common/actions/auth-error.js
+++ b/src/common/actions/auth-error.js
@@ -1,8 +1,23 @@
+// AUTH_ERROR is used when server-side auth fails
 export const AUTH_ERROR = 'AUTH_ERROR';
+
+// AUTH_EXPIRED is used when any client-side API response returns
+// 401 Unauthorized - quite likely because of expired session
+export const AUTH_EXPIRED = 'AUTH_EXPIRED';
 
 export function authError(message) {
   return {
     type: AUTH_ERROR,
     message
+  };
+}
+
+export function authExpired(error) {
+  return {
+    type: AUTH_EXPIRED,
+    payload: {
+      error: error
+    },
+    error: true
   };
 }

--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -6,6 +6,7 @@ import { APICompatibleError, checkStatus, getError, getMacaroonAuthHeader } from
 import { conf } from '../helpers/config';
 import { checkPackageUploadRequest, getAccountInfo } from './auth-store';
 import { requestBuilds } from './snap-builds';
+import { authExpired } from './auth-error';
 
 const BASE_URL = conf.get('BASE_URL');
 const STORE_API_URL = conf.get('STORE_API_URL');
@@ -173,6 +174,10 @@ export function registerName(repository, snapName, options={}) {
         await dispatch(requestBuilds(repository.url));
       }
     } catch (error) {
+      // detect if session has expired in the meantime
+      if (error.response && error.response.status === 401) {
+        dispatch(authExpired(error));
+      }
       dispatch(registerNameError(fullName, error));
     }
   };

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -48,7 +48,9 @@ export default class Header extends Component {
                     <a>Hi, {user.name || user.login}</a>
                   </li>
                   <li className={ style['p-navigation__link'] } role="menuitem">
-                    <a href="/auth/logout">Sign out</a>
+                    <a href="/auth/logout" onClick={ this.onLogoutClick.bind(this)}>
+                      Sign out
+                    </a>
                   </li>
                 </ul>
               :

--- a/src/common/components/session-overlay/index.js
+++ b/src/common/components/session-overlay/index.js
@@ -1,0 +1,59 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import { signOut } from '../../actions/auth-store';
+
+import Notification from '../vanilla-modules/notification';
+
+import style from './sessionOverlay.css';
+import containerStyle from '../../containers/container.css';
+
+export class SessionOverlay extends Component {
+
+  onReloadClick(event) {
+    event.preventDefault();
+    this.props.clearSession();
+    window.location.reload();
+  }
+
+  render() {
+    return !this.props.isExpired ? null : (
+      <div className={style.sessionOverlay}>
+        <div className={containerStyle.wrapper}>
+          <Notification appearance="caution">
+            Your session has expired.
+            {' '}
+            <a href="/" onClick={this.onReloadClick.bind(this)}>
+              Reload the page
+            </a>
+            {' '}
+            and sign in again.
+          </Notification>
+        </div>
+      </div>
+    );
+  }
+}
+
+SessionOverlay.propTypes = {
+  isExpired: PropTypes.bool,
+  clearSession: PropTypes.func
+};
+
+function mapStateToProps(state) {
+  const {
+    authError
+  } = state;
+
+  return {
+    isExpired: !!authError.expired
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    clearSession: () => dispatch(signOut())
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SessionOverlay);

--- a/src/common/components/session-overlay/sessionOverlay.css
+++ b/src/common/components/session-overlay/sessionOverlay.css
@@ -1,0 +1,12 @@
+.sessionOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255,255,255, .8);
+
+  padding-top: 60px;
+
+  z-index: 100;
+}

--- a/src/common/containers/app.js
+++ b/src/common/containers/app.js
@@ -5,6 +5,7 @@ import Helmet from 'react-helmet';
 import Header from '../components/header';
 import Footer from '../components/footer';
 import CookieNotification from '../components/cookie-notification';
+import SessionOverlay from '../components/session-overlay';
 
 import style from '../style/vanilla/css/footer.css';
 
@@ -27,6 +28,7 @@ export class App extends Component {
         />
         { this.props.children }
         <Footer />
+        <SessionOverlay />
         <CookieNotification />
       </div>
     );

--- a/src/common/middleware/call-api.js
+++ b/src/common/middleware/call-api.js
@@ -1,4 +1,5 @@
 import { checkStatus, getError } from '../helpers/api';
+import { authExpired } from '../actions/auth-error';
 
 // Action key that carries API call info interpreted by this Redux middleware.
 export const CALL_API = 'CALL_API';
@@ -72,6 +73,12 @@ export default (defaults) => () => (next) => (action) => {
     .catch((error) => {
       clearTimeout(loadingTimeout);
       error.action = action;
+
+      // if error is 401 Unauthorized it's quite likely that session had expired
+      if (error.response.status === 401) {
+        next(authExpired(error));
+      }
+
       if (failureType) {
         // if type of failure action is defined in settings
         // catch the error and pass it in failure action payload

--- a/src/common/reducers/auth-error.js
+++ b/src/common/reducers/auth-error.js
@@ -1,4 +1,4 @@
-import { AUTH_ERROR } from '../actions/auth-error';
+import { AUTH_ERROR, AUTH_EXPIRED } from '../actions/auth-error';
 
 export function authError(state = {}, action) {
   switch (action.type) {
@@ -6,6 +6,12 @@ export function authError(state = {}, action) {
       return {
         ...state,
         message: action.message
+      };
+    case AUTH_EXPIRED:
+      return {
+        ...state,
+        message: action.payload.error.json.payload.message,
+        expired: true
       };
     default:
       return state;


### PR DESCRIPTION
## Done

- added detecting `401 Unauthorized` to API request handlers
- when expired session is detected (API returns 401) overlay is shown asking to reload and sign in again
- fixed unhandled sign out link in header (to properly clear session on sign out)

## QA

Not to wait 2h for session to expire `src/server/helpers/session.js:11` can be edited to change session cookie maxAge from 2h to something shorter like a minute or 10 seconds.


- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in with Github
- Possibly sign in into the Store on one of repos
- As long as session is not expired everything should work as expected, no overlay should be shown unnecessarily
- After the session has expired try to make an action that requires user being sign in (like registering the name or adding new repo)
- Overlay should be shown with message about expired session
- Clicking 'Reload the page' in the notification should reload the page (possibly back to home page if user was on one of pages requiring auth)


## Issue / Card

Fixes #1003 

## Screenshots

<img width="1085" alt="screen shot 2018-05-23 at 12 53 29" src="https://user-images.githubusercontent.com/83575/40420796-cacfe09e-5e89-11e8-9275-896eeb7d030b.png">

