### PR TITLE
Catch missing snapcraft.yaml error and memcache it

### DIFF
--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -186,8 +186,19 @@ export const getSnapcraftData = async (repositoryUrl, token) => {
     logger.error(`Error getting ${cacheId} from memcached: ${error}`);
   }
 
-  const snapcraftYaml = await internalGetSnapcraftYaml(owner, name, token);
+  let snapcraftYaml = {};
   const snapcraftData = {};
+
+  try {
+    snapcraftYaml = await internalGetSnapcraftYaml(owner, name, token);
+  } catch (error) {
+    // if snapcraft.yaml was not found in repo, catch the error and memcache it
+    if (error.status === 404 && error.body) {
+      snapcraftYaml.error = error;
+    } else {
+      throw error;
+    }
+  }
 
   if (snapcraftYaml.contents) {
     for (const index of Object.keys(snapcraftYaml.contents)) {


### PR DESCRIPTION
## Done

Catch 404 error when snapcraft.yaml is not found in any of 3 possible locations and memcache this result (so we don't call GH API each time we poll for snaps).

## QA

It's a tricky one to QA without messing a bit with code and dev environment.
First of all, dev environment doesn't have memory cache (just nothing is cached), so either memcached needs to be run and configured or in memory cache (which can be enabled by changing `getMemcachedStub` into `getInMemoryMemcachedStub` in `helpers/memcached.js:82`).

To verify if memcached is used or GH API is called it's useful to add some logging into `helpers/github.js` `requestGithub` (which is called whenever any GH API is called) and/or inside `getSnapcraftData` in `handlers/github.js` which actually gets snapcraft.yaml data from memcached (line 181) or from GH API (line 193).

And the trickiest part of all is checking if webhook from GH clears memcached data. GH obviously will not call `localhost` so server needs to be exposed to public network and webhook in GH updated with proper URL/IP. Or, to properly QA it we may just merge it and deploy to staging.
 
- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in to go to 'My repos'
- Have any repo without snapcraft.yaml (or add a new one)
- Verify that error about missing snapcraft.yaml is memcached and GH API is not called every time we poll for list of repos


## Issue / Card

Fixes #1090
