### PR TITLE
Allow removing repo with name owned by other user

### DIFF
--- a/src/common/components/repository-row/dropdowns/dropdowns.css
+++ b/src/common/components/repository-row/dropdowns/dropdowns.css
@@ -20,6 +20,15 @@
   margin-bottom: 1em;
 }
 
+.warningCaption {
+  composes: caption;
+  margin-left: 1em;
+}
+
+.warningIcon {
+  margin-left: -1em;
+}
+
 .snapNameInput {
   width: 250px;
 }

--- a/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
@@ -6,27 +6,33 @@ import { IconWarning } from '../../vanilla-modules/icons';
 
 import styles from './dropdowns.css';
 
-const getRemoveWarningMessage = (isBuilt, registeredName) => {
-  let warningText;
-  if (isBuilt) {
-    warningText = (
-      'Removing this repo will delete all its builds and build logs.'
-    );
-  } else {
-    warningText = (
-      'Are you sure you want to remove this repo from the list?'
-    );
-  }
-  if (registeredName !== null) {
-    warningText += ' The name will remain registered.';
-  }
+const getRemoveWarningMessage = (isBuilt, registeredName, isOwnerOfRegisteredName) => {
   // XXX cjwatson 2017-02-28: Once we can get hold of published states for
   // builds, we should also implement this design requirement:
   //   Separately, if any build has been published, the text should end
   //   with:
   //     Released builds will remain published.
 
-  return warningText;
+  return (
+    <div className={styles.warningCaption}>
+      <p>
+        <span className={styles.warningIcon}><IconWarning /></span>
+        &nbsp;&nbsp;
+        Are you sure you want to remove this repo from the list?
+      </p>
+      <ul>
+        {registeredName !== null && isOwnerOfRegisteredName &&
+          <li>The name will remain registered.</li>
+        }
+        {registeredName !== null && !isOwnerOfRegisteredName &&
+          <li>You don’t own the <strong>{registeredName}</strong> name and will not be able to configure this repo again.</li>
+        }
+        {isBuilt &&
+          <li>Removing this repo will delete all its builds and build logs.</li>
+        }
+      </ul>
+    </div>
+  );
 };
 
 const RemoveRepoDropdown = (props) => {
@@ -41,9 +47,7 @@ const RemoveRepoDropdown = (props) => {
   } = props;
 
   let message = (
-    <span>
-      <IconWarning /> { getRemoveWarningMessage(isBuilt, registeredName) }
-    </span>
+    getRemoveWarningMessage(isBuilt, registeredName, isOwnerOfRegisteredName)
   );
 
   let actionButton = (
@@ -56,12 +60,18 @@ const RemoveRepoDropdown = (props) => {
   );
 
   if (registeredName) {
-    if (isAuthenticated) {
-      if (!isOwnerOfRegisteredName) {
-        message = `To remove this repo, contact the person who registered the name ${registeredName}.`;
-        actionButton = null;
-      }
-    } else {
+    if (!isOwnerOfRegisteredName) {
+      actionButton = (
+        <Button
+          appearance="negative"
+          onClick={ onRemoveClick }
+        >
+          I understand the consequences, remove this repo
+        </Button>
+      );
+    }
+
+    if (!isAuthenticated) {
       message = `You can remove this repo only if you registered the name ${registeredName}.`;
 
       actionButton = (

--- a/src/common/middleware/call-api.js
+++ b/src/common/middleware/call-api.js
@@ -75,7 +75,7 @@ export default (defaults) => () => (next) => (action) => {
       error.action = action;
 
       // if error is 401 Unauthorized it's quite likely that session had expired
-      if (error.response.status === 401) {
+      if (error.response && error.response.status === 401) {
         next(authExpired(error));
       }
 

--- a/test/unit/src/common/components/repository-row/dropdowns/t_remove-repo-dropdown.js
+++ b/test/unit/src/common/components/repository-row/dropdowns/t_remove-repo-dropdown.js
@@ -89,11 +89,11 @@ describe('<RemoveRepoDropdown />', () => {
         });
 
         it('should render proper warning message', () => {
-          expect(view.html()).toContain('To remove this repo, contact the person who registered the name');
+          expect(view.html()).toContain('and will not be able to configure this repo again');
         });
 
-        it('should render Remove button', () => {
-          expect(view.find('Button').length).toEqual(0);
+        it('should render Remove button with consequences warning', () => {
+          expect(view.find('Button').last().prop('children')).toEqual('I understand the consequences, remove this repo');
         });
       });
     });


### PR DESCRIPTION
## Done

Allows removing repo even if registered name is owned by someone else, but warn user about doing it.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in
- Have a repo with a registered name owned by someone else (for example added by other org member)
- Try to remove it (Sign in to the store)
- You should see a warning explaining that you don't own the name and bug red button
- You should be able to remove the repo


## Issue / Card

Fixes #998 

## Screenshots

<img width="1060" alt="screen shot 2018-05-24 at 16 38 51" src="https://user-images.githubusercontent.com/83575/40492943-f6a72eaa-5f71-11e8-98a4-91467bf818a1.png">

