### PR TITLE
Batch "ensure webhook" calls to LP (for better performance)

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -401,7 +401,12 @@ const internalFindSnaps = async (owner, token) => {
   ));
   snaps = snaps.concat(result.entries);
   // ensure LP webhook is set up for all the snaps
-  await Promise.all(snaps.map(snap => ensureWebhook(snap)));
+  // but batch it by 10 not to overload LP servers
+  const BATCH_SIZE = 10;
+  for (let i=0; i < snaps.length; i += BATCH_SIZE) {
+    const batch = snaps.slice(i, i + BATCH_SIZE);
+    await Promise.all(batch.map(snap => ensureWebhook(snap)));
+  }
   return snaps;
 };
 

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -400,9 +400,8 @@ const internalFindSnaps = async (owner, token) => {
     )
   ));
   snaps = snaps.concat(result.entries);
-  for (const snap of snaps) {
-    await ensureWebhook(snap);
-  }
+  // ensure LP webhook is set up for all the snaps
+  await Promise.all(snaps.map(snap => ensureWebhook(snap)));
   return snaps;
 };
 


### PR DESCRIPTION
## Done

Part of #1006 

When debugging the timing of `findSnaps` response it turned out that (when nothing is memcached) one of the biggest bottlenecks is checking with LP that every repo/snap has a webhook.

When there is over 70 repos the whole response takes ~30 seconds, ~25 of which is spent asking LP to for webhooks for every snap one after another.

This PR changes for loop into `Promise.all` to check webhooks for all snaps concurrently.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in, wait for repos to load
- Everything should work as expected, if you have many repos they should probably load quicker then before


## Issue / Card

Part of fixes around #1006
