### PR TITLE
Add error notification to My repos page

### DIFF
--- a/src/common/components/first-time-heading/index.js
+++ b/src/common/components/first-time-heading/index.js
@@ -73,7 +73,7 @@ class FirstTimeHeading extends Component {
   render() {
     const { message, progress } = this.getCurrentState();
 
-    return (
+    return ( (message || progress) &&
       <div className={styles.firstTimeHeading}>
         { this.renderProgress(progress) }
         { this.renderMessage(message) }

--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -7,6 +7,7 @@ import { fetchUserSnaps } from '../../actions/snaps';
 import { fetchBuilds } from '../../actions/snap-builds';
 import { LinkButton } from '../vanilla-modules/button';
 import { HeadingThree } from '../vanilla-modules/heading';
+import Notification from '../vanilla-modules/notification';
 import FirstTimeHeading from '../first-time-heading';
 import RepositoriesList from '../repositories-list';
 import styles from './repositories-home.css';
@@ -86,9 +87,22 @@ class RepositoriesHome extends Component {
     // should it fetch data for first time heading (it already does need it anyway probably)
     // move it to HOC?
 
+    let errorNotification = null;
+    const { error } = this.props.snaps;
+
+    if (error) {
+      const message = (error.json && error.json.payload)
+        ? error.json.payload.message
+        : 'There was an error completing your request, please try again later.';
+      errorNotification = (
+        <Notification appearance='negative'>{ message }</Notification>
+      );
+    }
+
     return (
       <div>
         <FirstTimeHeading isOnMyRepos={true} />
+        { errorNotification }
         <div className={ styles['button-container'] }>
           <HeadingThree>Repos to build</HeadingThree>
           <div>

--- a/test/unit/src/common/components/repositories-home/t_repositories-home.js
+++ b/test/unit/src/common/components/repositories-home/t_repositories-home.js
@@ -47,6 +47,40 @@ describe('The RepositoriesHome component', () => {
     });
   });
 
+  context('when there is an error', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      props = {
+        auth: {
+          authenticated: true
+        },
+        user: {},
+        entities: {
+          snaps: {}
+        },
+        snaps: {
+          error: {
+            json: {
+              payload: {
+                message: 'Test error'
+              }
+            }
+          }
+        },
+        snapBuilds: {},
+        updateSnaps: expect.createSpy(),
+        router: {}
+      };
+
+      wrapper = shallow(<RepositoriesHome { ...props } />);
+    });
+
+    it('should render error message', () => {
+      expect(wrapper.find('Notification').html()).toContain('Test error');
+    });
+  });
+
   context('when user is logged in', () => {
     let wrapper;
 


### PR DESCRIPTION
## Done

Adds error notification to 'My repos' page when there is any error fetching list of snaps.

Currently if snaps listing request ends up with an error we show 'No repos' without any error message.
This at least gives user an idea that something is wrong.

## QA

To mock some server side error you can throw error inside `findSnaps` in `handlers/launchpad.js:556`. 

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in
- Wait for snaps listing to return an error
- Error should show up above snaps list
- Error message will depend on whatever error was returned (and if API failing gave any error message)


## Issue / Card

Helps with #1006

## Screenshots

<img width="1068" alt="screen shot 2018-05-25 at 16 07 31" src="https://user-images.githubusercontent.com/83575/40548962-80ea4326-6036-11e8-95d0-27b7aaaf3a19.png">

