### PR TITLE
Only store one token per session

### DIFF
--- a/src/server/handlers/universal.js
+++ b/src/server/handlers/universal.js
@@ -42,9 +42,7 @@ export const handleMatch = (req, res, error, redirectLocation, renderProps) => {
       initialState.user = req.session.user;
     }
 
-    const csrfToken = req.session.csrfTokens
-      ? req.session.csrfTokens[req.session.csrfTokens.length - 1]
-      : null;
+    const csrfToken = req.session.csrfToken || null;
 
     if (req.session.error) {
       initialState['authError'] = { message: req.session.error };

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -10,7 +10,7 @@ import { conf } from '../../../../../src/server/helpers/config.js';
 
 describe('The GitHub API endpoint', () => {
   const app = Express();
-  const session = { 'token': 'secret', 'csrfTokens': ['blah']  };
+  const session = { 'token': 'secret', 'csrfToken': 'blah' };
 
   let scope;
 

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -30,7 +30,7 @@ import { conf } from '../../../../../src/server/helpers/config.js';
 
 describe('The Launchpad API endpoint', () => {
   const app = Express();
-  const session = { token: 'secret', user: { id: 123, login: 'anowner' }, 'csrfTokens': ['blah'] };
+  const session = { token: 'secret', user: { id: 123, login: 'anowner' }, 'csrfToken': 'blah' };
   app.use((req, res, next) => {
     req.session = session;
     next();


### PR DESCRIPTION
## Done

Attempting generate and store CSRF tokens was causing some race conditions when multiple tabs were opened at once and multiple tokens were stored into the session overriding each other.

It seems that generating token per request is not necessary. Single token per user session is secure enough (as per [synchronizer tokens](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29_Prevention_Cheat_Sheet#Synchronizer_.28CSRF.29_Tokens)). So this PR simplifies token generation to just use one token per authenticated user and fixes the issue with concurrent requests overriding each other tokens.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- While you are not signed in there should be no token generated
- Sign in with GH - new token should be generated (it is visible as part of state passed to the app in HTML source)
- Open multiple tabs for you repositories
- Each tab should use the same token (see in HTML source)
- You should be able to trigger manual builds without getting `401 Unauthorized` error on console


## Issue / Card

Fixes #1084 

