### PR TITLE
Add some logging around association handle storing in session

### DIFF
--- a/src/server/openid/relyingparty.js
+++ b/src/server/openid/relyingparty.js
@@ -1,6 +1,9 @@
 import openid from 'openid';
 import { conf } from '../helpers/config';
 import { Macaroon, Teams } from './extensions';
+import logging from '../logging';
+
+const logger = logging.getLogger('login');
 
 openid['Macaroon'] = Macaroon;
 openid['Teams'] = Teams;
@@ -18,6 +21,11 @@ const saveAssociation = (session) => {
       type,
       secret
     };
+
+    if (session.user) {
+      logger.info(`Saving association handle for user ${session.user.login}`);
+    }
+
     callback(null); // Custom implementations may report error as first argument
   };
 };
@@ -25,8 +33,18 @@ const saveAssociation = (session) => {
 const loadAssociation = (session) => {
   return (handle, callback) => {
     if (session.association) {
+      if (session.user) {
+        logger.info(`Loading association handle for user ${session.user.login}`);
+      }
+
       callback(null, session.association);
     } else {
+      if (session.user) {
+        logger.error(`No association handle found for user ${session.user.login}`);
+      } else {
+        logger.error('No association handle found, no user found in session');
+      }
+
       callback(null, null);
     }
   };


### PR DESCRIPTION
## Done

Add some additional logging around association handle saving in session to possibly better understand reasons behind issues like #623

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in with GH
- Sign in to store on one of the repos (to register name or delete it)
- Look into server logs/console - association handle saving/loading should be logged

