### PR TITLE
Improve logging GH auth errors

### DIFF
--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -127,6 +127,7 @@ export const internalListOrganizations = async (owner, token) => {
   }
 
   try {
+    logger.info(`Getting list of organizations from GitHub (user: ${owner}, token: ${token})`);
     const response = await requestGitHub.get('/user/orgs', {
       token, json: true
     });
@@ -140,7 +141,7 @@ export const internalListOrganizations = async (owner, token) => {
     await getMemcached().set(cacheId, response.body, 3600);
     return response.body;
   } catch (error) {
-    logger.error(`Error getting list of organizations from GitHub: ${error}`);
+    logger.error(`Error getting list of organizations from GitHub (user: ${owner}, token: ${token}): ${error}`);
     return [];
   }
 };

--- a/src/server/helpers/github.js
+++ b/src/server/helpers/github.js
@@ -8,9 +8,12 @@ import request from 'request';
 import url from 'url';
 
 import { conf } from '../helpers/config';
+import logging from '../logging';
 
 const GITHUB_API_ENDPOINT = conf.get('GITHUB_API_ENDPOINT');
 const HTTP_PROXY = conf.get('HTTP_PROXY');
+
+const logger = logging.getLogger('express');
 
 export const requestGitHub = (options) => {
   return new Promise((resolve, reject) => {
@@ -26,6 +29,8 @@ export const requestGitHub = (options) => {
       params.headers['Authorization'] = `token ${params.token}`;
       delete params.token;
     } else {
+      logger.info(`Calling GH API with service authorisation (no user auth token): ${params.uri}`);
+
       // Make request with service authorisation rather than user
       // authorisation.  This should be kept to a minimum because GitHub
       // imposes a rate limit on each authorisation token, and so a central

--- a/src/server/helpers/prepared-error.js
+++ b/src/server/helpers/prepared-error.js
@@ -6,6 +6,11 @@ export class PreparedError extends Error {
     super();
     this.status = status;
     this.body = body;
+
+    // propagate error message for better logging
+    if (this.body && this.body.payload) {
+      this.message = this.body.payload.message;
+    }
   }
 }
 


### PR DESCRIPTION
## Done

We started noticing strange errors in logs that requests to GH to list user orgs fail:
`2018-06-06 11:21:30.534Z ERROR express "Error getting list of organizations from GitHub: Error"`

But because these issues cannot be reproduced outside of prod environment and current logging is not enough to find the cause this PR adds mode logging around getting organisations and makes sure our errors have better message then just 'Error'.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in, load your repos
- Here should be some additional logging about getting list or user orgs

