### PR TITLE
Fail early on expired session

### DIFF
--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -51,8 +51,12 @@ class RepositoriesHome extends Component {
       updateSnaps(owner);
       if (!interval) {
         interval = setInterval(() => {
+          const isVisible = (!document.visibilityState || document.visibilityState == 'visible');
+          const { isSessionExpired } = this.props;
+
           // don't fetch snaps (and builds) if page is in the background
-          if (!document.visibilityState || document.visibilityState == 'visible') {
+          // or if user session has expired
+          if (isVisible && !isSessionExpired) {
             this.snapsUpdatedTimestamp = Date.now();
             updateSnaps(owner);
           }
@@ -123,6 +127,7 @@ class RepositoriesHome extends Component {
 
 RepositoriesHome.propTypes = {
   auth: PropTypes.object.isRequired,
+  isSessionExpired: PropTypes.bool.isRequired,
   user: PropTypes.object,
   entities: PropTypes.object,
   snaps: PropTypes.object.isRequired,
@@ -136,6 +141,7 @@ RepositoriesHome.propTypes = {
 function mapStateToProps(state) {
   const {
     auth,
+    authError,
     user,
     entities,
     snaps,
@@ -144,6 +150,7 @@ function mapStateToProps(state) {
 
   return {
     auth,
+    isSessionExpired: !!authError.expired,
     user,
     entities,
     snaps,

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -551,6 +551,10 @@ const getSnapRepoData = async(snap, token) => {
 };
 
 export const findSnaps = async (req, res) => {
+  if (!req.session || !req.session.token) {
+    return res.status(401).send(RESPONSE_NOT_LOGGED_IN);
+  }
+
   const owner = req.query.owner || req.session.user.login;
   try {
     const rawSnaps = await internalFindSnaps(owner, req.session.token);
@@ -585,6 +589,10 @@ export const findSnaps = async (req, res) => {
 };
 
 export const findSnap = async (req, res) => {
+  if (!req.session || !req.session.token) {
+    return res.status(401).send(RESPONSE_NOT_LOGGED_IN);
+  }
+
   try {
     const snap = await internalFindSnap(req.query.repository_url);
 


### PR DESCRIPTION
## Done

Making sure `findSnaps` and `findSnap` handlers fail early when session is expired not to call APIs unnecessarily with nonexistent auth token.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in to go to my repos page.
- Expire the session (for example by removing session cookie)
- Next time repos list is polled you should recieve 401 error, expired session should be detected
- When session is expired polling should be stopped (no further requests should be sent every 30 seconds)


## Issue / Card

Fixes #1117

## Screenshots

<img width="1129" alt="screen shot 2018-06-07 at 12 31 42" src="https://user-images.githubusercontent.com/83575/41095615-3c65db40-6a52-11e8-8097-8737cf13b3f7.png">

