### PR TITLE
Update badge cache headers as per GH expects it

### DIFF
--- a/src/server/handlers/badge.js
+++ b/src/server/handlers/badge.js
@@ -29,6 +29,8 @@ export const badge = async (req, res) => {
         badgeName = latestBuild.badge;
       }
     }
+
+    res.setHeader('Cache-Control', 'no-cache');
     return res.sendFile(path.join(BADGES_PATH, `${badgeName}.svg`));
   } catch (err) {
     logger.error(`Error generating badge for repo ${repoUrl}`, err);


### PR DESCRIPTION
## Done

Adds `no-cache` header to badge

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Go to a page of any repo
- Look at network panel for request for badge image
- Response should have `no-cache` value in `Cache-Control` header


## Issue / Card

Fixes #1101 
