### PR TITLE
Fix snaps API request credentials to make sure session cookie is sent

### DIFF
--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -17,7 +17,10 @@ export function fetchSnap(repositoryUrl) {
     },
     [CALL_API]: {
       path: `/api/launchpad/snaps?repository_url=${encodeURIComponent(repositoryUrl)}`,
-      types: [FETCH_BUILDS, FETCH_SNAP_SUCCESS]
+      types: [FETCH_BUILDS, FETCH_SNAP_SUCCESS],
+      options: {
+        credentials: 'same-origin'
+      }
     }
   };
 }


### PR DESCRIPTION
## Done

Seems that recently merged PR #1118 introduced a bug (Marking as critical as it's already on production).

Opening builds page in another tab was always ending with 'session expired' error, because session cookie was not sent with first API request.

This fixes that.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in
- On 'My repos' page open couple of repos in separate tabs
- They should open without showing that session is expired
