### PR TITLE
Force session save/load when dealing with openid association handle

### DIFF
--- a/src/server/openid/relyingparty.js
+++ b/src/server/openid/relyingparty.js
@@ -22,31 +22,36 @@ const saveAssociation = (session) => {
       secret
     };
 
-    if (session.user) {
-      logger.info(`Saving association handle for user ${session.user.login}`);
-    }
+    // make sure session is saved before proceeding
+    session.save((err) => {
+      if (session.user) {
+        logger.info(`Saving association handle for user ${session.user.login}`);
+      }
 
-    callback(null); // Custom implementations may report error as first argument
+      callback(err);
+    });
   };
 };
 
 const loadAssociation = (session) => {
   return (handle, callback) => {
-    if (session.association) {
-      if (session.user) {
-        logger.info(`Loading association handle for user ${session.user.login}`);
-      }
+    session.reload((err) => {
+      if (session.association) {
+        if (session.user) {
+          logger.info(`Loading association handle for user ${session.user.login}`);
+        }
 
-      callback(null, session.association);
-    } else {
-      if (session.user) {
-        logger.error(`No association handle found for user ${session.user.login}`);
+        callback(err, session.association);
       } else {
-        logger.error('No association handle found, no user found in session');
-      }
+        if (session.user) {
+          logger.error(`No association handle found for user ${session.user.login}`);
+        } else {
+          logger.error('No association handle found, no user found in session');
+        }
 
-      callback(null, null);
-    }
+        callback(err, null);
+      }
+    });
   };
 };
 

--- a/test/routes/src/server/routes/t_login.js
+++ b/test/routes/src/server/routes/t_login.js
@@ -12,7 +12,9 @@ const OPENID_VERIFY_URL = conf.get('OPENID_VERIFY_URL');
 
 describe('login routes', () => {
   const app = Express();
-  const session = {};
+  const session = {
+    save: (callback) => { callback(); }
+  };
   app.use((req, res, next) => {
     req.session = session;
     next();

--- a/test/unit/src/server/openid/t_relyingparty.js
+++ b/test/unit/src/server/openid/t_relyingparty.js
@@ -80,7 +80,9 @@ describe('RelyingParty with teams extension', () => {
 describe('RelyingParty saveAssociation', () => {
 
   let mySaveAssociation;
-  let mySession = {};
+  let mySession = {
+    save: (callback) => { callback(); }
+  };
 
   before(() => {
     mySaveAssociation = saveAssociation(mySession);
@@ -115,7 +117,8 @@ describe('RelyingParty loadAssociation', () => {
 
   let myLoadAssociation;
   let mySession = {
-    association: 'foo'
+    association: 'foo',
+    reload: (callback) => { callback(); }
   };
   let spy;
 
@@ -134,14 +137,16 @@ describe('RelyingParty loadAssociation', () => {
     });
 
     it('should callback with session association', () => {
-      expect(spy).toHaveBeenCalledWith(null, 'foo');
+      expect(spy).toHaveBeenCalledWith(undefined, 'foo');
     });
   });
 });
 
 describe('RelyingParty removeAssociation', () => {
   let myRemoveAssociation;
-  let mySession = {};
+  let mySession = {
+    association: 'foo'
+  };
 
   before(() => {
     myRemoveAssociation = removeAssociation(mySession);
@@ -153,6 +158,6 @@ describe('RelyingParty removeAssociation', () => {
 
   it('should delete session association', () => {
     myRemoveAssociation();
-    expect(mySession).toEqual({});
+    expect(mySession.association).toBe(undefined);
   });
 });


### PR DESCRIPTION
## Done

As an attempt to fix (or at least improve) issue with Invalid Association Handle error (#623) forces saving/reloading session when dealing with openid association handle to make sure session is fully saved/loaded.

Express session [documentation suggests](https://github.com/expressjs/session#sessionsavecallback) that manually saving session may be useful in case of redirects (that we do when logging in via SSO), so hopefully this will fix (or at least limit the possibility of) invalid handle issue.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in to BSI
- Sign in to store (on one of the repos)
- Everything should work (try to register a name, trigger some build, etc)


## Issue / Card

Related to #623

