### PR TITLE
Update navigation and redirect to snapcraft.io on login and logout

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ EXTRA_PORTS='8082'
 WEBPACK_DEV_URL=http://0.0.0.0:8082
 BASE_URL=http://0.0.0.0:8083
 OPENID_VERIFY_URL=http://0.0.0.0:8083/login/verify
+SNAPCRAFT_URL=https://snapcraft.io

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ version-info.txt
 
 # Environment variables
 environments/development.env
+environments/dev.env
 
 # Development and test SQLite databases
 /dev.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,6 @@ version-info.txt
 
 # Environment variables
 environments/development.env
-environments/dev.env
 
 # Development and test SQLite databases
 /dev.sqlite3

--- a/environments/production.env
+++ b/environments/production.env
@@ -1,6 +1,7 @@
 HOST=0.0.0.0
 PORT=8000
 BASE_URL=https://build.snapcraft.io
+SNAPCRAFT_URL=https://snapcraft.io
 NODE_ENV=production
 COOKIE_SECURE=true
 UBUNTU_SSO_URL=https://login.ubuntu.com

--- a/environments/staging.env
+++ b/environments/staging.env
@@ -1,6 +1,7 @@
 HOST=0.0.0.0
 PORT=8000
 BASE_URL=https://build.staging.snapcraft.io
+SNAPCRAFT_URL=https://staging.snapcraft.io
 NODE_ENV=production
 COOKIE_SECURE=true
 UBUNTU_SSO_URL=https://login.ubuntu.com

--- a/environments/test.env
+++ b/environments/test.env
@@ -3,6 +3,8 @@ ENVIRONMENT=test
 
 BASE_URL=http://localhost:8000
 
+SNAPCRAFT_URL=https://snapcraft.io
+
 UBUNTU_SSO_URL=https://login.ubuntu.com
 OPENID_VERIFY_URL=http://localhost:8000/login/verify
 

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -2,6 +2,8 @@ import React, { Component, PropTypes } from 'react';
 
 import { signOut } from '../../actions/auth-store';
 
+import { conf } from '../../helpers/config';
+
 import style from '../../style/vanilla/css/navigation.css';
 import { IconChevron, IconUser } from '../vanilla-modules/icons';
 
@@ -19,6 +21,8 @@ export default class Header extends Component {
   render() {
     const { authenticated, user } = this.props;
 
+    const SNAPCRAFT_URL = conf.get('SNAPCRAFT_URL');
+
     return (
       <header id="navigation" className={ style['p-navigation'] }>
         <div className={ style['p-navigation__banner'] }>
@@ -34,13 +38,13 @@ export default class Header extends Component {
         <nav className={ style['p-navigation__nav'] } role="menubar">
           <ul className={ style['p-navigation__links']} role="menu">
             <li className={ style['p-navigation__link'] } role="menuitem">
-              <a href="https://snapcraft.io/store/">Store</a>
+              <a href={ `${SNAPCRAFT_URL}/store` }>Store</a>
             </li>
             <li className={ style['p-navigation__link'] } role="menuitem">
-              <a href="https://snapcraft.io/blog/">Blog</a>
+              <a href={ `${SNAPCRAFT_URL}/blog` }>Blog</a>
             </li>
             <li className={ style['p-navigation__link'] } role="menuitem">
-              <a className={ authenticated ? '' : style['is-selected'] } href="https://snapcraft.io/build">Build</a>
+              <a className={ authenticated ? '' : style['is-selected'] } href={ `${SNAPCRAFT_URL}/build}` }>Build</a>
             </li>
             <li className={ style['p-navigation__link'] } role="menuitem">
               <a href="https://docs.snapcraft.io">Docs</a>
@@ -60,13 +64,13 @@ export default class Header extends Component {
                   </a>
                   <ul className={ style['p-dropdown__menu']} id="account-menu" aria-hidden={ !this.state.showUserDropdown }>
                     <li className={ style['p-navigation__link']} role="menuitem">
-                      <a href="https://snapcraft.io/account/snaps">My published snaps</a>
+                      <a href={ `${SNAPCRAFT_URL}/account/snaps` } >My published snaps</a>
                     </li>
                     <li className={ style['p-navigation__link']} role="menuitem">
                       <a href={ `/user/${user.login}`} className={ style['is-selected']}>Build with GitHub</a>
                     </li>
                     <li className={ style['p-navigation__link']} role="menuitem">
-                      <a href="https://snapcraft.io/account/details">Account details</a>
+                      <a href={ `${SNAPCRAFT_URL}/account/details` }>Account details</a>
                     </li>
                     <li className={ style['p-navigation__link']} role="menuitem">
                       <a href="/auth/logout" onClick={ this.onLogoutClick.bind(this)}>Sign out</a>
@@ -77,7 +81,7 @@ export default class Header extends Component {
             ) : (
               <ul className={ style['p-navigation__links--right']} role="menu">
                 <li className={ style['p-navigation__link'] } role="menuitem">
-                  <a href="/auth/authenticate">
+                  <a href="http://0.0.0.0:8004/login?next=/login/bsi">
                     <IconUser/>Developer account
                   </a>
                 </li>

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -63,7 +63,7 @@ export default class Header extends Component {
                       <a href="https://snapcraft.io/account/snaps">My published snaps</a>
                     </li>
                     <li className={ style['p-navigation__link']} role="menuitem">
-                      <a href="/auth/authenticate" className={ style['is-selected']}>Build with GitHub</a>
+                      <a href={ `/user/${user.login}`} className={ style['is-selected']}>Build with GitHub</a>
                     </li>
                     <li className={ style['p-navigation__link']} role="menuitem">
                       <a href="https://snapcraft.io/account/details">Account details</a>

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -7,6 +7,7 @@ import { conf } from '../../helpers/config';
 import style from '../../style/vanilla/css/navigation.css';
 import { IconChevron, IconUser } from '../vanilla-modules/icons';
 
+const SNAPCRAFT_URL = conf.get('SNAPCRAFT_URL');
 const brandmark = 'https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg';
 
 export default class Header extends Component {
@@ -20,8 +21,6 @@ export default class Header extends Component {
 
   render() {
     const { authenticated, user } = this.props;
-
-    const SNAPCRAFT_URL = conf.get('SNAPCRAFT_URL');
 
     return (
       <header id="navigation" className={ style['p-navigation'] }>
@@ -60,7 +59,7 @@ export default class Header extends Component {
                   <a className={ style['p-dropdown__toggle']} aria-controls="account-menu" aria-expanded={ this.state.showUserDropdown }
                     onClick={ this.onDropdownClick.bind(this)}
                   >
-                    {user.name || user.login}<IconChevron/>
+                    {user.name || user.login}<IconChevron className={ style['p-nav-icon']}/>
                   </a>
                   <ul className={ style['p-dropdown__menu']} id="account-menu" aria-hidden={ !this.state.showUserDropdown }>
                     <li className={ style['p-navigation__link']} role="menuitem">
@@ -82,7 +81,7 @@ export default class Header extends Component {
               <ul className={ style['p-navigation__links--right']} role="menu">
                 <li className={ style['p-navigation__link'] } role="menuitem">
                   <a href="/auth/authenticate">
-                    <IconUser/>Developer account
+                    <IconUser className={ style['p-nav-icon']}/>Developer account
                   </a>
                 </li>
               </ul>

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -35,7 +35,7 @@ export default class Header extends Component {
           <a href="#navigation-closed" className={ style['p-navigation__toggle--close'] } title="close menu">Close menu</a>
         </div>
         <nav className={ style['p-navigation__nav'] } role="menubar">
-          <ul className={ style['p-navigation__links']} role="menu">
+          <ul className={ style['p-navigation__links'] } role="menu">
             <li className={ style['p-navigation__link'] } role="menuitem">
               <a href={ `${SNAPCRAFT_URL}/store` }>Store</a>
             </li>
@@ -54,34 +54,34 @@ export default class Header extends Component {
           </ul>
           { authenticated
             ? (
-              <ul className={ style['p-navigation__links--right']} role="menu">
-                <li className={ style['p-navigation__link']} role="menuitem">
-                  <a className={ style['p-dropdown__toggle']} aria-controls="account-menu" aria-expanded={ this.state.showUserDropdown }
+              <ul className={ style['p-navigation__links--right'] } role="menu">
+                <li className={ style['p-navigation__link'] } role="menuitem">
+                  <a className={ style['p-dropdown__toggle'] } aria-controls="account-menu" aria-expanded={ this.state.showUserDropdown }
                     onClick={ this.onDropdownClick.bind(this)}
                   >
-                    {user.name || user.login}<IconChevron className={ style['p-nav-icon']}/>
+                    {user.name || user.login}<IconChevron className={ style['p-nav-icon'] }/>
                   </a>
-                  <ul className={ style['p-dropdown__menu']} id="account-menu" aria-hidden={ !this.state.showUserDropdown }>
-                    <li className={ style['p-navigation__link']} role="menuitem">
+                  <ul className={ style['p-dropdown__menu'] } id="account-menu" aria-hidden={ !this.state.showUserDropdown }>
+                    <li className={ style['p-navigation__link'] } role="menuitem">
                       <a href={ `${SNAPCRAFT_URL}/account/snaps` } >My published snaps</a>
                     </li>
-                    <li className={ style['p-navigation__link']} role="menuitem">
-                      <a href={ `/user/${user.login}`} className={ style['is-selected']}>Build with GitHub</a>
+                    <li className={ style['p-navigation__link'] } role="menuitem">
+                      <a href={ `/user/${user.login}`} className={ style['is-selected'] }>Build with GitHub</a>
                     </li>
-                    <li className={ style['p-navigation__link']} role="menuitem">
+                    <li className={ style['p-navigation__link'] } role="menuitem">
                       <a href={ `${SNAPCRAFT_URL}/account/details` }>Account details</a>
                     </li>
-                    <li className={ style['p-navigation__link']} role="menuitem">
+                    <li className={ style['p-navigation__link'] } role="menuitem">
                       <a href="/auth/logout" onClick={ this.onLogoutClick.bind(this)}>Sign out</a>
                     </li>
                   </ul>
                 </li>
               </ul>
             ) : (
-              <ul className={ style['p-navigation__links--right']} role="menu">
+              <ul className={ style['p-navigation__links--right'] } role="menu">
                 <li className={ style['p-navigation__link'] } role="menuitem">
                   <a href="/auth/authenticate">
-                    <IconUser className={ style['p-nav-icon']}/>Developer account
+                    <IconUser className={ style['p-nav-icon'] }/>Developer account
                   </a>
                 </li>
               </ul>

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -81,7 +81,7 @@ export default class Header extends Component {
             ) : (
               <ul className={ style['p-navigation__links--right']} role="menu">
                 <li className={ style['p-navigation__link'] } role="menuitem">
-                  <a href="http://0.0.0.0:8004/login?next=/login/bsi">
+                  <a href={ `${SNAPCRAFT_URL}/login?next=/login/bsi` }>
                     <IconUser/>Developer account
                   </a>
                 </li>

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -3,7 +3,7 @@ import React, { Component, PropTypes } from 'react';
 import { signOut } from '../../actions/auth-store';
 
 import style from '../../style/vanilla/css/navigation.css';
-import {IconChevron, IconUser} from "../vanilla-modules/icons";
+import { IconChevron, IconUser } from '../vanilla-modules/icons';
 
 const brandmark = 'https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg';
 
@@ -40,7 +40,7 @@ export default class Header extends Component {
               <a href="https://snapcraft.io/blog/">Blog</a>
             </li>
             <li className={ style['p-navigation__link'] } role="menuitem">
-              <a className={ style['is-selected'] } href="https://snapcraft.io/build">Build</a>
+              <a className={ authenticated ? '' : style['is-selected'] } href="https://snapcraft.io/build">Build</a>
             </li>
             <li className={ style['p-navigation__link'] } role="menuitem">
               <a href="https://docs.snapcraft.io">Docs</a>
@@ -54,7 +54,8 @@ export default class Header extends Component {
               <ul className={ style['p-navigation__links--right']} role="menu">
                 <li className={ style['p-navigation__link']} role="menuitem">
                   <a className={ style['p-dropdown__toggle']} aria-controls="account-menu" aria-expanded={ this.state.showUserDropdown }
-                    onClick={ this.onDropdownClick.bind(this)}>
+                    onClick={ this.onDropdownClick.bind(this)}
+                  >
                     {user.name || user.login}<IconChevron/>
                   </a>
                   <ul className={ style['p-dropdown__menu']} id="account-menu" aria-hidden={ !this.state.showUserDropdown }>
@@ -62,7 +63,7 @@ export default class Header extends Component {
                       <a href="https://snapcraft.io/account/snaps">My published snaps</a>
                     </li>
                     <li className={ style['p-navigation__link']} role="menuitem">
-                      <a href="/auth/authenticate">Build with GitHub</a>
+                      <a href="/auth/authenticate" className={ style['is-selected']}>Build with GitHub</a>
                     </li>
                     <li className={ style['p-navigation__link']} role="menuitem">
                       <a href="https://snapcraft.io/account/details">Account details</a>

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -2,73 +2,100 @@ import React, { Component, PropTypes } from 'react';
 
 import { signOut } from '../../actions/auth-store';
 
-import containerStyles from '../../containers/container.css';
 import style from '../../style/vanilla/css/navigation.css';
+import {IconChevron, IconUser} from "../vanilla-modules/icons";
 
 const brandmark = 'https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg';
 
 export default class Header extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showUserDropdown: false
+    };
+  }
+
   render() {
     const { authenticated, user } = this.props;
 
     return (
       <header id="navigation" className={ style['p-navigation'] }>
-        <div className={ containerStyles.wrapper }>
-          <div className={ style['p-navigation__banner'] }>
-            <div className={ style['p-navigation__logo'] }>
-              <a className={ style['p-navigation__link'] } href="https://snapcraft.io">
-                <img className={ style['p-navigation__image'] } src={ brandmark } alt="Snapcraft" />
-              </a>
-            </div>
-            <a href="#navigation" className={ style['p-navigation__toggle--open'] } title="menu">Menu</a>
-            <a href="#navigation-closed" className={ style['p-navigation__toggle--close'] } title="close menu">Close menu</a>
+        <div className={ style['p-navigation__banner'] }>
+          <div className={ style['p-navigation__logo'] }>
+            <a className={ style['p-navigation__link'] } href="https://snapcraft.io">
+              <img className={ style['p-navigation__image'] } src={ brandmark } alt="Snapcraft" />
+            </a>
           </div>
-          <nav className={ style['p-navigation__nav'] } role="menubar">
-            <ul className={ style['p-navigation__links']} role="menu">
-              <li className={ style['p-navigation__link'] } role="menuitem">
-                <a href="https://snapcraft.io/store/">Store</a>
-              </li>
-              <li className={ style['p-navigation__link'] } role="menuitem">
-                <a className={ style['is-selected'] } href="/">Build</a>
-              </li>
-              <li className={ style['p-navigation__link'] } role="menuitem">
-                <a className={ style['p-link--external'] } href="https://dashboard.snapcraft.io/snaps">My snaps</a>
-              </li>
-              <li className={ style['p-navigation__link'] } role="menuitem">
-                <a href="https://docs.snapcraft.io">Docs</a>
-              </li>
-              <li className={ style['p-navigation__link'] } role="menuitem">
-                <a className={ style['p-link--external'] } href="https://forum.snapcraft.io/categories">Forum</a>
-              </li>
-            </ul>
-            { authenticated
-              ? (
-                <ul className={ style['p-navigation__links--right']} role="menu">
-                  <li className={ style['p-navigation__item'] } role="menuitem">
-                    <a>Hi, {user.name || user.login}</a>
-                  </li>
-                  <li className={ style['p-navigation__link'] } role="menuitem">
-                    <a href="/auth/logout" onClick={ this.onLogoutClick.bind(this)}>
-                      Sign out
-                    </a>
-                  </li>
-                </ul>
-              ) : (
-                <ul className={ style['p-navigation__links--right']} role="menu">
-                  <li className={ style['p-navigation__link'] } role="menuitem">
-                    <a href="/auth/authenticate">Sign in with GitHub</a>
-                  </li>
-                </ul>
-              )
-            }
-          </nav>
+
+          <a href="#navigation" className={ style['p-navigation__toggle--open'] } title="menu">Menu</a>
+          <a href="#navigation-closed" className={ style['p-navigation__toggle--close'] } title="close menu">Close menu</a>
         </div>
+        <nav className={ style['p-navigation__nav'] } role="menubar">
+          <ul className={ style['p-navigation__links']} role="menu">
+            <li className={ style['p-navigation__link'] } role="menuitem">
+              <a href="https://snapcraft.io/store/">Store</a>
+            </li>
+            <li className={ style['p-navigation__link'] } role="menuitem">
+              <a href="https://snapcraft.io/blog/">Blog</a>
+            </li>
+            <li className={ style['p-navigation__link'] } role="menuitem">
+              <a className={ style['is-selected'] } href="https://snapcraft.io/build">Build</a>
+            </li>
+            <li className={ style['p-navigation__link'] } role="menuitem">
+              <a href="https://docs.snapcraft.io">Docs</a>
+            </li>
+            <li className={ style['p-navigation__link'] } role="menuitem">
+              <a className={ style['p-link--external'] } href="https://forum.snapcraft.io/categories">Forum</a>
+            </li>
+          </ul>
+          { authenticated
+            ? (
+              <ul className={ style['p-navigation__links--right']} role="menu">
+                <li className={ style['p-navigation__link']} role="menuitem">
+                  <a className={ style['p-dropdown__toggle']} aria-controls="account-menu" aria-expanded={ this.state.showUserDropdown }
+                    onClick={ this.onDropdownClick.bind(this)}>
+                    {user.name || user.login}<IconChevron/>
+                  </a>
+                  <ul className={ style['p-dropdown__menu']} id="account-menu" aria-hidden={ !this.state.showUserDropdown }>
+                    <li className={ style['p-navigation__link']} role="menuitem">
+                      <a href="https://snapcraft.io/account/snaps">My published snaps</a>
+                    </li>
+                    <li className={ style['p-navigation__link']} role="menuitem">
+                      <a href="/auth/authenticate">Build with GitHub</a>
+                    </li>
+                    <li className={ style['p-navigation__link']} role="menuitem">
+                      <a href="https://snapcraft.io/account/details">Account details</a>
+                    </li>
+                    <li className={ style['p-navigation__link']} role="menuitem">
+                      <a href="/auth/logout" onClick={ this.onLogoutClick.bind(this)}>Sign out</a>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            ) : (
+              <ul className={ style['p-navigation__links--right']} role="menu">
+                <li className={ style['p-navigation__link'] } role="menuitem">
+                  <a href="/auth/authenticate">
+                    <IconUser/>Developer account
+                  </a>
+                </li>
+              </ul>
+            )
+          }
+        </nav>
       </header>
     );
   }
 
   onLogoutClick() {
     this.props.dispatch(signOut());
+  }
+
+  onDropdownClick() {
+    this.setState({
+      showUserDropdown: !this.state.showUserDropdown
+    });
   }
 }
 

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -81,7 +81,7 @@ export default class Header extends Component {
             ) : (
               <ul className={ style['p-navigation__links--right']} role="menu">
                 <li className={ style['p-navigation__link'] } role="menuitem">
-                  <a href={ `${SNAPCRAFT_URL}/login?next=/login/bsi` }>
+                  <a href="/auth/authenticate">
                     <IconUser/>Developer account
                   </a>
                 </li>

--- a/src/common/components/vanilla-modules/icons/index.js
+++ b/src/common/components/vanilla-modules/icons/index.js
@@ -23,6 +23,7 @@ const Icon = (props) => {
     [iconStyle(appearance)]: true,
     [iconStyle(size)]: true,
     [iconStyle('inherit-color')]: inheritColor,
+    [props.className]: props.className
   });
 
   // Aria-hidden is required as icons shouldn't be visible to
@@ -61,7 +62,8 @@ Icon.propTypes = {
     'spinner'
   ]),
   inheritColor: PropTypes.bool,
-  size: PropTypes.oneOf(['medium', 'large', 'x-large', 'xx-large'])
+  size: PropTypes.oneOf(['medium', 'large', 'x-large', 'xx-large']),
+  className: PropTypes.string
 };
 
 // Icon type components

--- a/src/common/style/vanilla/css/navigation.css
+++ b/src/common/style/vanilla/css/navigation.css
@@ -524,13 +524,13 @@
 
 .p-navigation .p-navigation__links--right {
   margin-right: 20px; }
-  .p-navigation .p-navigation__links--right i {
+  .p-navigation .p-navigation__links--right .p-nav-icon {
     margin-right: .5rem; }
   .p-navigation .p-navigation__links--right:last-of-type {
     border-right: none; }
   .p-navigation .p-navigation__links--right .p-dropdown__toggle {
     cursor: pointer; }
-    .p-navigation .p-navigation__links--right .p-dropdown__toggle i {
+    .p-navigation .p-navigation__links--right .p-dropdown__toggle .p-nav-icon {
       width: 12px;
       height: 12px;
       margin-right: 0;

--- a/src/common/style/vanilla/css/navigation.css
+++ b/src/common/style/vanilla/css/navigation.css
@@ -169,11 +169,15 @@
         float: left;
         width: auto; } }
     .p-navigation .p-navigation__link, .p-navigation .p-navigation__links .p-navigation__item, .p-navigation .p-navigation__links--right .p-navigation__item,
-    .p-navigation .p-navigation__link > a, .p-navigation .p-navigation__links .p-navigation__item > a, .p-navigation .p-navigation__links--right .p-navigation__item > a {
+    .p-navigation .p-navigation__link > a,
+    .p-navigation .p-navigation__links .p-navigation__item > a,
+    .p-navigation .p-navigation__links--right .p-navigation__item > a {
       border-bottom: 0;
       display: block; }
       .p-navigation .p-navigation__link:hover, .p-navigation .p-navigation__links .p-navigation__item:hover, .p-navigation .p-navigation__links--right .p-navigation__item:hover,
-      .p-navigation .p-navigation__link > a:hover, .p-navigation .p-navigation__links .p-navigation__item > a:hover, .p-navigation .p-navigation__links--right .p-navigation__item > a:hover {
+      .p-navigation .p-navigation__link > a:hover,
+      .p-navigation .p-navigation__links .p-navigation__item > a:hover,
+      .p-navigation .p-navigation__links--right .p-navigation__item > a:hover {
         text-decoration: none; }
     .p-navigation .p-navigation__link:last-child, .p-navigation .p-navigation__links .p-navigation__item:last-child, .p-navigation .p-navigation__links--right .p-navigation__item:last-child {
       margin-bottom: 0; }
@@ -200,13 +204,15 @@
           .p-navigation .p-navigation__links .p-navigation__link:last-child, .p-navigation .p-navigation__links--right .p-navigation__link:last-child, .p-navigation .p-navigation__links .p-navigation__item:last-child, .p-navigation .p-navigation__links--right .p-navigation__item:last-child {
             border-bottom: 1px solid #cdcdcd; } }
     .p-navigation .p-navigation__links .p-navigation__link > a, .p-navigation .p-navigation__links--right .p-navigation__link > a, .p-navigation .p-navigation__links .p-navigation__item > a, .p-navigation .p-navigation__links--right .p-navigation__item > a,
-    .p-navigation .p-navigation__links > a, .p-navigation .p-navigation__links--right > a {
+    .p-navigation .p-navigation__links > a,
+    .p-navigation .p-navigation__links--right > a {
       color: #111;
       font-size: .875rem;
       padding: 0.84375rem 0.5rem; }
       @media (min-width: 769px) {
         .p-navigation .p-navigation__links .p-navigation__link > a, .p-navigation .p-navigation__links--right .p-navigation__link > a, .p-navigation .p-navigation__links .p-navigation__item > a, .p-navigation .p-navigation__links--right .p-navigation__item > a,
-        .p-navigation .p-navigation__links > a, .p-navigation .p-navigation__links--right > a {
+        .p-navigation .p-navigation__links > a,
+        .p-navigation .p-navigation__links--right > a {
           color: #f7f7f7;
           padding-left: 1.25rem;
           padding-right: 1.25rem; } }
@@ -319,18 +325,18 @@
         width: auto; } }
     .p-navigation--sidebar .p-navigation__link, .p-navigation--sidebar .p-navigation .p-navigation__links .p-navigation__item, .p-navigation .p-navigation__links .p-navigation--sidebar .p-navigation__item, .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__item, .p-navigation .p-navigation__links--right .p-navigation--sidebar .p-navigation__item,
     .p-navigation--sidebar .p-navigation__link > a,
-    .p-navigation--sidebar .p-navigation .p-navigation__links .p-navigation__item > a, .p-navigation .p-navigation__links
-    .p-navigation--sidebar .p-navigation__item > a,
-    .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__item > a, .p-navigation .p-navigation__links--right
-    .p-navigation--sidebar .p-navigation__item > a {
+    .p-navigation--sidebar .p-navigation .p-navigation__links .p-navigation__item > a,
+    .p-navigation .p-navigation__links .p-navigation--sidebar .p-navigation__item > a,
+    .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__item > a,
+    .p-navigation .p-navigation__links--right .p-navigation--sidebar .p-navigation__item > a {
       border-bottom: 0;
       display: block; }
       .p-navigation--sidebar .p-navigation__link:hover, .p-navigation--sidebar .p-navigation .p-navigation__links .p-navigation__item:hover, .p-navigation .p-navigation__links .p-navigation--sidebar .p-navigation__item:hover, .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__item:hover, .p-navigation .p-navigation__links--right .p-navigation--sidebar .p-navigation__item:hover,
       .p-navigation--sidebar .p-navigation__link > a:hover,
-      .p-navigation--sidebar .p-navigation .p-navigation__links .p-navigation__item > a:hover, .p-navigation .p-navigation__links
-      .p-navigation--sidebar .p-navigation__item > a:hover,
-      .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__item > a:hover, .p-navigation .p-navigation__links--right
-      .p-navigation--sidebar .p-navigation__item > a:hover {
+      .p-navigation--sidebar .p-navigation .p-navigation__links .p-navigation__item > a:hover,
+      .p-navigation .p-navigation__links .p-navigation--sidebar .p-navigation__item > a:hover,
+      .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__item > a:hover,
+      .p-navigation .p-navigation__links--right .p-navigation--sidebar .p-navigation__item > a:hover {
         text-decoration: none; }
     .p-navigation--sidebar .p-navigation__link:last-child, .p-navigation--sidebar .p-navigation .p-navigation__links .p-navigation__item:last-child, .p-navigation .p-navigation__links .p-navigation--sidebar .p-navigation__item:last-child, .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__item:last-child, .p-navigation .p-navigation__links--right .p-navigation--sidebar .p-navigation__item:last-child {
       margin-bottom: 0; }
@@ -358,16 +364,16 @@
             border-bottom: 1px solid #cdcdcd; } }
     .p-navigation--sidebar .p-navigation__links .p-navigation__link > a, .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__link > a, .p-navigation .p-navigation--sidebar .p-navigation__links--right .p-navigation__link > a, .p-navigation--sidebar .p-navigation .p-navigation__links .p-navigation__item > a, .p-navigation .p-navigation--sidebar .p-navigation__links .p-navigation__item > a, .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__item > a, .p-navigation .p-navigation--sidebar .p-navigation__links--right .p-navigation__item > a,
     .p-navigation--sidebar .p-navigation__links > a,
-    .p-navigation--sidebar .p-navigation .p-navigation__links--right > a, .p-navigation
-    .p-navigation--sidebar .p-navigation__links--right > a {
+    .p-navigation--sidebar .p-navigation .p-navigation__links--right > a,
+    .p-navigation .p-navigation--sidebar .p-navigation__links--right > a {
       color: #111;
       font-size: .875rem;
       padding: 0.84375rem 0.5rem; }
       @media (min-width: 769px) {
         .p-navigation--sidebar .p-navigation__links .p-navigation__link > a, .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__link > a, .p-navigation .p-navigation--sidebar .p-navigation__links--right .p-navigation__link > a, .p-navigation--sidebar .p-navigation .p-navigation__links .p-navigation__item > a, .p-navigation .p-navigation--sidebar .p-navigation__links .p-navigation__item > a, .p-navigation--sidebar .p-navigation .p-navigation__links--right .p-navigation__item > a, .p-navigation .p-navigation--sidebar .p-navigation__links--right .p-navigation__item > a,
         .p-navigation--sidebar .p-navigation__links > a,
-        .p-navigation--sidebar .p-navigation .p-navigation__links--right > a, .p-navigation
-        .p-navigation--sidebar .p-navigation__links--right > a {
+        .p-navigation--sidebar .p-navigation .p-navigation__links--right > a,
+        .p-navigation .p-navigation--sidebar .p-navigation__links--right > a {
           color: #111;
           padding-left: 1.25rem;
           padding-right: 1.25rem; } }
@@ -467,7 +473,8 @@
       display: block; }
     .is-selected .p-icon--plus {
       display: none; }
-    .is-selected + .sidebar__second-level, .is-selected + .sidebar__third-level {
+    .is-selected + .sidebar__second-level,
+    .is-selected + .sidebar__third-level {
       display: block; }
     .p-navigation--sidebar .sidebar__second-level .is-deepest-level,
     .p-navigation--sidebar .sidebar__third-level .is-deepest-level {
@@ -481,17 +488,30 @@
     top: 0.75rem;
     transition: all .5s ease-in-out; }
 
+.p-navigation .p-navigation__logo {
+  height: 3rem;
+  margin: 0 1rem 0 1.5rem; }
+
 .p-navigation .p-navigation__image {
-  display: block; }
+  display: block;
+  max-height: 2rem;
+  min-height: 1.5rem; }
 
 @media (min-width: 769px) {
   .p-navigation .p-navigation__links .p-navigation__link, .p-navigation .p-navigation__links--right .p-navigation__link, .p-navigation .p-navigation__links .p-navigation__item, .p-navigation .p-navigation__links--right .p-navigation__item {
-    border-left: 1px solid #585858; }
+    border-left: 1px solid transparent;
+    position: relative; }
+    .p-navigation .p-navigation__links .p-navigation__link a, .p-navigation .p-navigation__links--right .p-navigation__link a, .p-navigation .p-navigation__links .p-navigation__item a, .p-navigation .p-navigation__links--right .p-navigation__item a {
+      font-size: 1rem;
+      padding: .75rem 1rem; }
     .p-navigation .p-navigation__links .p-navigation__link a:hover, .p-navigation .p-navigation__links--right .p-navigation__link a:hover, .p-navigation .p-navigation__links .p-navigation__item a:hover, .p-navigation .p-navigation__links--right .p-navigation__item a:hover,
-    .p-navigation .p-navigation__links .p-navigation__link .is-selected, .p-navigation .p-navigation__links--right .p-navigation__link .is-selected, .p-navigation .p-navigation__links .p-navigation__item .is-selected, .p-navigation .p-navigation__links--right .p-navigation__item .is-selected {
+    .p-navigation .p-navigation__links .p-navigation__link .is-selected,
+    .p-navigation .p-navigation__links--right .p-navigation__link .is-selected,
+    .p-navigation .p-navigation__links .p-navigation__item .is-selected,
+    .p-navigation .p-navigation__links--right .p-navigation__item .is-selected {
       background: #111111; }
     .p-navigation .p-navigation__links .p-navigation__link:last-of-type, .p-navigation .p-navigation__links--right .p-navigation__link:last-of-type, .p-navigation .p-navigation__links .p-navigation__item:last-of-type, .p-navigation .p-navigation__links--right .p-navigation__item:last-of-type {
-      border-right: 1px solid #585858; } }
+      border-right: 1px solid transparent; } }
 
 .p-navigation .p-navigation__links .p-navigation__item, .p-navigation .p-navigation__links--right .p-navigation__item {
   border-left: none;
@@ -502,8 +522,35 @@
   .p-navigation .p-navigation__links .p-navigation__item a:hover, .p-navigation .p-navigation__links--right .p-navigation__item a:hover {
     background: transparent; }
 
-.p-navigation .p-navigation__links--right:last-of-type {
-  border-right: none; }
+.p-navigation .p-navigation__links--right {
+  margin-right: 20px; }
+  .p-navigation .p-navigation__links--right i {
+    margin-right: .5rem; }
+  .p-navigation .p-navigation__links--right:last-of-type {
+    border-right: none; }
+  .p-navigation .p-navigation__links--right .p-dropdown__toggle {
+    cursor: pointer; }
+    .p-navigation .p-navigation__links--right .p-dropdown__toggle i {
+      width: 12px;
+      height: 12px;
+      margin-right: 0;
+      margin-left: .5rem; }
+    .p-navigation .p-navigation__links--right .p-dropdown__toggle[aria-expanded="true"] i {
+      transform: rotate(180deg); }
+  .p-navigation .p-navigation__links--right .p-dropdown__menu {
+    background-color: #252525;
+    margin: 0;
+    padding: 0;
+    display: none;
+    position: absolute;
+    right: 0;
+    white-space: nowrap; }
+    .p-navigation .p-navigation__links--right .p-dropdown__menu[aria-hidden="false"] {
+      display: block; }
+    .p-navigation .p-navigation__links--right .p-dropdown__menu .p-navigation__link, .p-navigation .p-navigation__links--right .p-dropdown__menu .p-navigation__item {
+      border-left: 0;
+      float: none;
+      width: 100%; }
 
 @media (min-width: 769px) {
   .p-navigation .p-navigation__links--right {

--- a/src/common/style/vanilla/navigation.scss
+++ b/src/common/style/vanilla/navigation.scss
@@ -13,11 +13,18 @@ $color-navigation-background: #252525;
 // CUSTOM OVERRIDES
 
 .p-navigation {
-  $navigation-border-color: lighten($color-navigation-background, 20%);
+  $navigation-border-color: transparent;
   $navigation-hover-color: darken($color-navigation-background, 8%); // from #252525 to #111
+
+  .p-navigation__logo {
+    height: 3rem;
+    margin: 0 1rem 0 1.5rem;
+  }
 
   .p-navigation__image {
     display: block;
+    max-height: 2rem;
+    min-height: 1.5rem;
   }
 
     .p-navigation__links {
@@ -25,6 +32,12 @@ $color-navigation-background: #252525;
       @media (min-width: $breakpoint-navigation-threshold + 1) {
       .p-navigation__link {
         border-left: 1px solid $navigation-border-color;
+        position: relative;
+
+        a {
+          font-size: 1rem;
+          padding: .75rem 1rem;
+        }
 
         a:hover,
         .is-selected {
@@ -60,9 +73,49 @@ $color-navigation-background: #252525;
   // right aligned sign-in navigation
   .p-navigation__links--right {
     @extend .p-navigation__links;
+    margin-right: 20px;
+
+    i {
+      margin-right: .5rem;
+    }
 
     &:last-of-type {
       border-right: none;
+    }
+
+    .p-dropdown__toggle {
+      cursor: pointer;
+
+      i {
+        width: 12px;
+        height: 12px;
+        margin-right: 0;
+        margin-left: .5rem;
+      }
+
+      &[aria-expanded="true"] i {
+        transform: rotate(180deg);
+      }
+    }
+
+    .p-dropdown__menu {
+      background-color: $color-navigation-background;
+      margin: 0;
+      padding: 0;
+      display: none;
+      position: absolute;
+      right: 0;
+      white-space: nowrap;
+
+      &[aria-hidden="false"] {
+        display: block;
+      }
+
+      .p-navigation__link {
+        border-left: 0;
+        float: none;
+        width: 100%;
+      }
     }
   }
 

--- a/src/common/style/vanilla/navigation.scss
+++ b/src/common/style/vanilla/navigation.scss
@@ -75,7 +75,7 @@ $color-navigation-background: #252525;
     @extend .p-navigation__links;
     margin-right: 20px;
 
-    i {
+    .p-nav-icon {
       margin-right: .5rem;
     }
 
@@ -86,7 +86,7 @@ $color-navigation-background: #252525;
     .p-dropdown__toggle {
       cursor: pointer;
 
-      i {
+      .p-nav-icon {
         width: 12px;
         height: 12px;
         margin-right: 0;

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -2,6 +2,7 @@ export default {
   HOST: '0.0.0.0',
   PORT: '8000',
   BASE_URL: 'http://localhost:8000',
+  SNAPCRAFT_URL: 'https://snapcraft.io',
   WEBPACK_DEV_URL: 'http://localhost:8001',
   NODE_ENV: 'development',
   ENVIRONMENT: 'development',

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -14,6 +14,7 @@ const GITHUB_AUTH_CLIENT_ID = conf.get('GITHUB_AUTH_CLIENT_ID');
 const GITHUB_AUTH_CLIENT_SECRET = conf.get('GITHUB_AUTH_CLIENT_SECRET');
 const GITHUB_AUTH_REDIRECT_URL = conf.get('GITHUB_AUTH_REDIRECT_URL');
 const HTTP_PROXY = conf.get('HTTP_PROXY');
+const SNAPCRAFT_URL = conf.get('SNAPCRAFT_URL');
 const logger = logging.getLogger('login');
 
 export const authenticate = (req, res, next) => {
@@ -146,6 +147,6 @@ export const logout = (req, res, next) => {
       return next(new Error('Failed to log out.'));
     }
     // FIXME redirect to page that initiated the sign in request
-    res.redirect('https://snapcraft.io/logout?no_redirect=true');
+    res.redirect(`${SNAPCRAFT_URL}/logout?no_redirect=true`);
   });
 };

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -146,6 +146,6 @@ export const logout = (req, res, next) => {
       return next(new Error('Failed to log out.'));
     }
     // FIXME redirect to page that initiated the sign in request
-    res.redirect('/');
+    res.redirect('https://snapcraft.io/logout');
   });
 };

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -146,6 +146,6 @@ export const logout = (req, res, next) => {
       return next(new Error('Failed to log out.'));
     }
     // FIXME redirect to page that initiated the sign in request
-    res.redirect('https://snapcraft.io/logout');
+    res.redirect('https://snapcraft.io/logout?no_redirect=true');
   });
 };

--- a/src/server/helpers/config.js
+++ b/src/server/helpers/config.js
@@ -11,6 +11,7 @@ import dotenv from 'dotenv';
 const CLIENT_SIDE_WHITELIST = [
   'NODE_ENV',
   'BASE_URL',
+  'SNAPCRAFT_URL',
   'GITHUB_API_ENDPOINT',
   'GITHUB_AUTH_CLIENT_ID',
   'UBUNTU_SSO_URL',

--- a/test/unit/src/common/components/header/t_header.js
+++ b/test/unit/src/common/components/header/t_header.js
@@ -17,7 +17,7 @@ describe('<Header />', function() {
     });
 
     it('should render sign in link', () => {
-      expect(element.find({ href: '/auth/authenticate' }).length).toBe(1);
+      expect(element.find({ href: 'https://snapcraft.io/login?next=/login/bsi' }).length).toBe(1);
     });
   });
 

--- a/test/unit/src/common/components/header/t_header.js
+++ b/test/unit/src/common/components/header/t_header.js
@@ -17,7 +17,7 @@ describe('<Header />', function() {
     });
 
     it('should render sign in link', () => {
-      expect(element.find({ href: 'https://snapcraft.io/login?next=/login/bsi' }).length).toBe(1);
+      expect(element.find({ href: '/auth/authenticate' }).length).toBe(1);
     });
   });
 

--- a/test/unit/src/common/components/header/t_header.js
+++ b/test/unit/src/common/components/header/t_header.js
@@ -36,7 +36,7 @@ describe('<Header />', function() {
     });
 
     it('should render user name', () => {
-      expect(element.html().indexOf('Hi, Joe Doe')).toBeGreaterThan(0);
+      expect(element.html().indexOf('Joe Doe')).toBeGreaterThan(0);
     });
 
     it('should render sign out link', () => {
@@ -53,7 +53,7 @@ describe('<Header />', function() {
       });
 
       it('should render login as user name', () => {
-        expect(element.html().indexOf('Hi, jdoe')).toBeGreaterThan(0);
+        expect(element.html().indexOf('jdoe')).toBeGreaterThan(0);
       });
     });
   });

--- a/test/unit/src/server/handlers/t_github-auth.js
+++ b/test/unit/src/server/handlers/t_github-auth.js
@@ -28,10 +28,10 @@ describe('login', () => {
       expect(req.session.destroy.calledOnce).toBe(true);
     });
 
-    it('on success redirects to home', () => {
+    it('on success redirects to snapcraft.io/logout', () => {
       req.session.destroy.callsArgWith(0, false);
       logout(req, res, next);
-      expect(res.redirect.calledWith('/')).toBe(true);
+      expect(res.redirect.calledWith('https://snapcraft.io/logout')).toBe(true);
     });
 
     it('on error calls next with error', () => {

--- a/test/unit/src/server/handlers/t_github-auth.js
+++ b/test/unit/src/server/handlers/t_github-auth.js
@@ -28,10 +28,10 @@ describe('login', () => {
       expect(req.session.destroy.calledOnce).toBe(true);
     });
 
-    it('on success redirects to snapcraft.io/logout', () => {
+    it('on success redirects to snapcraft.io/logout?no_redirect=true', () => {
       req.session.destroy.callsArgWith(0, false);
       logout(req, res, next);
-      expect(res.redirect.calledWith('https://snapcraft.io/logout')).toBe(true);
+      expect(res.redirect.calledWith('https://snapcraft.io/logout?no_redirect=true')).toBe(true);
     });
 
     it('on error calls next with error', () => {


### PR DESCRIPTION
This PR is one of the pieces required to make build.snapcraft.io and snapcraft.io seamless.

The idea is that `https://build.snapcraft.io` will redirect to `https://snapcraft.io/build`, however, after logging in to `https://snapcraft.io` you'll be able to click the 'Build with GitHub' link in the user menu which will redirect to `https://build.snapcraft.io/auth/authenticate`. Either starting the authentication dance, or redirecting to `https://build.snapcraft.io/user/{github_user}` where the navigation will be the same as on `https://snapcraft.io` (see the note below).

When a user logs out of either site they will be redirected to the log out of both, ending up back on the `https://snapcraft.io` homepage.

## Done

Fixes https://github.com/canonical-websites/snapcraft.io/issues/921

- Made the header visually the same as snapcraft.io
- Added drop down when logged in as on snapcraft.io
- Redirected `/auth/logout` to `https://snapcraft.io/logout`

### Note

The user's name in the header will only match if they've set it the same on launchpad and github. There's nothing we can do about that, but I'm sure they know that they are the same person.

## QA

- Checkout the branch
- `npm start -- --env=environment/dev.env`
- Compare the header to https://snapcraft.io
- Login
- Compare the header to https://snapcraft.io
- Logout
- Be on https://snapcraft.io

## TODO before merging

- Redirect https://snapcraft.io/logout to https://build.snapcraft.io/auth/logout and catch the second redirect implemented in this PR so as not to loop https://github.com/canonical-websites/snapcraft.io/issues/970