### PR TITLE
Upgrade to sinon 6.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "react-addons-test-utils": "^15.4.0",
     "redux-mock-store": "^1.2.1",
     "shonkwrap": "^1.3.0",
-    "sinon": "^1.17.6",
+    "sinon": "^6.1.4",
     "sqlite3": "^3.1.8",
     "std-mocks": "^1.0.1",
     "strip-ansi": "^3.0.1",

--- a/test/unit/src/server/handlers/t_github-auth.js
+++ b/test/unit/src/server/handlers/t_github-auth.js
@@ -37,7 +37,9 @@ describe('login', () => {
     it('on error calls next with error', () => {
       req.session.destroy.callsArgWith(0, true);
       logout(req, res, next);
-      expect(next.calledWith(new Error())).toBe(true);
+      expect(next.calledWithMatch((arg) => {
+        return arg instanceof Error && arg.message === 'Failed to log out.';
+      })).toBe(true);
     });
 
   });


### PR DESCRIPTION
sinon added deep comparison of errors way back in 2.0.0 or so, which
needed a small test adjustment.