### PR TITLE
Fix spelling of GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ## Issue / Card
 
-[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]
+[List of links to GitHub issues/bugs and cards if needed - e.g. `Fixes #1`]
 
 ## Screenshots
 

--- a/mocks/service/github/responses.js
+++ b/mocks/service/github/responses.js
@@ -26,7 +26,7 @@ export function okayNewHookCreated(req, res) {
     url: req.body.config.url,
     headers: {
       'Content-Type': 'application/json',
-      'X-Github-Delivery': '72d3162e-cc78-11e3-81ab-4c9367dc0958',
+      'X-GitHub-Delivery': '72d3162e-cc78-11e3-81ab-4c9367dc0958',
       'User-Agent': 'GitHub-Hookshot/044aadd',
       'X-GitHub-Event': 'ping',
       'X-Hub-Signature': hmac.digest('hex')

--- a/setup.sh
+++ b/setup.sh
@@ -39,11 +39,11 @@ read
 
 echo
 read -p "Enter the GitHub client id: " client_id
-read -p "Enter the Github client secret: " client_secret
-read -p "Enter Github Username: " username
-read -s -p "Enter Github Password: " password
+read -p "Enter the GitHub client secret: " client_secret
+read -p "Enter GitHub Username: " username
+read -s -p "Enter GitHub Password: " password
 echo
-read -p "Enter Github 2FA: " tfa
+read -p "Enter GitHub 2FA: " tfa
 
 user="$username:$password"
 content_type="Content-Type: application/json"

--- a/src/common/components/traffic-lights/index.js
+++ b/src/common/components/traffic-lights/index.js
@@ -42,7 +42,7 @@ export default class TrafficLights extends Component {
 
     this.state = {
       signals: [{
-        message: 'Connect to Github'
+        message: 'Connect to GitHub'
       }, {
         message: 'Choose a repo'
       }, {

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -354,7 +354,7 @@ const getRequest = (owner, name, token, secret) => {
 /*
  * parse_link_header()
  *
- * Parse the Github Link HTTP header used for pageination
+ * Parse the GitHub Link HTTP header used for pageination
  * http://developer.github.com/v3/#pagination
  *
  * Modified by kfenn to return page numbers instead of urls


### PR DESCRIPTION
The service is called GitHub, not Github.  Spell it consistently.