### PR TITLE
Redirect homepage to snapcraft.io/build

### DIFF
--- a/src/server/handlers/universal.js
+++ b/src/server/handlers/universal.js
@@ -9,6 +9,10 @@ import assets from '../../../webpack-assets.json';
 
 let routes = require('../../common/routes').default;
 
+export const homepage = (req, res) => {
+  res.redirect(302, conf.get('SNAPCRAFT_URL') + '/build');
+};
+
 export const universal = (req, res) => {
   if (process.env.NODE_ENV === 'development') {
     // Hot-reload application files when changes

--- a/src/server/routes/universal.js
+++ b/src/server/routes/universal.js
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 
-import { universal } from '../handlers/universal';
+import { universal, homepage } from '../handlers/universal';
 
 const router = Router();
 
+router.get('/', homepage);
 router.get('*', universal);
 
 export default router;


### PR DESCRIPTION
## Done

- Redirect homepage to snapcraft.io/build

## QA

- Check out this feature branch
- Add to `environments/dev.env` the line: `SNAPCRAFT_URL=http://localhost:8004`
- Run the site using the command ```npm start -- --env=environments/dev.env```
- Run snapcraft.io
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- It should redirect you to: http://localhost:8004/build
- Try to login and set up your account
- Should work as usual


## Issue / Card

Fixes https://github.com/CanonicalLtd/snap-squad/issues/674
