### PR TITLE
Add IoT link to navigation

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -43,6 +43,9 @@ export default class Header extends Component {
               <a href={ `${SNAPCRAFT_URL}/blog` }>Blog</a>
             </li>
             <li className={ style['p-navigation__link'] } role="menuitem">
+              <a href={ `${SNAPCRAFT_URL}/iot` }>IoT</a>
+            </li>
+            <li className={ style['p-navigation__link'] } role="menuitem">
               <a className={ authenticated ? '' : style['is-selected'] } href={ `${SNAPCRAFT_URL}/build` }>Build</a>
             </li>
             <li className={ style['p-navigation__link'] } role="menuitem">


### PR DESCRIPTION
Added IoT to the navigation in preparation for https://github.com/canonical-websites/snapcraft.io/pull/994

# QA

- Pull the branch
- `npm start -- --environments/dev.env`
- Visit http://0.0.0.0:8083/auth/authenticate
- See the IoT link in the header

## Screenshots

![screenshot_2018-08-20 build snapcraft io - home](https://user-images.githubusercontent.com/479384/44334123-9b11f700-a468-11e8-8744-a64b8ce1e9d8.png)

