### PR TITLE
Make site width the same as snapcraft.io

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -5,6 +5,8 @@ import { signOut } from '../../actions/auth-store';
 import { conf } from '../../helpers/config';
 
 import style from '../../style/vanilla/css/navigation.css';
+import containerStyles from '../../containers/container.css';
+
 import { IconChevron, IconUser } from '../vanilla-modules/icons';
 
 const SNAPCRAFT_URL = conf.get('SNAPCRAFT_URL');
@@ -24,73 +26,72 @@ export default class Header extends Component {
 
     return (
       <header id="navigation" className={ style['p-navigation'] }>
-        <div className={ style['p-navigation__banner'] }>
-          <div className={ style['p-navigation__logo'] }>
-            <a className={ style['p-navigation__link'] } href="https://snapcraft.io">
-              <img className={ style['p-navigation__image'] } src={ brandmark } alt="Snapcraft" />
-            </a>
-          </div>
+        <div className={ containerStyles['wrapper'] }>
+          <div className={ style['p-navigation__banner'] }>
+            <div className={ style['p-navigation__logo'] }>
+              <a className={ style['p-navigation__link'] } href="https://snapcraft.io">
+                <img className={ style['p-navigation__image'] } src={ brandmark } alt="Snapcraft" />
+              </a>
+            </div>
 
-          <a href="#navigation" className={ style['p-navigation__toggle--open'] } title="menu">Menu</a>
-          <a href="#navigation-closed" className={ style['p-navigation__toggle--close'] } title="close menu">Close menu</a>
+            <a href="#navigation" className={ style['p-navigation__toggle--open'] } title="menu">Menu</a>
+            <a href="#navigation-closed" className={ style['p-navigation__toggle--close'] } title="close menu">Close menu</a>
+          </div>
+          <nav className={ style['p-navigation__nav'] } role="menubar">
+            <ul className={ style['p-navigation__links'] } role="menu">
+              <li className={ style['p-navigation__link'] } role="menuitem">
+                <a href={ `${SNAPCRAFT_URL}/store` }>Store</a>
+              </li>
+              <li className={ style['p-navigation__link'] } role="menuitem">
+                <a href={ `${SNAPCRAFT_URL}/blog` }>Blog</a>
+              </li>
+              <li className={ style['p-navigation__link'] } role="menuitem">
+                <a className={ authenticated ? '' : style['is-selected'] } href={ `${SNAPCRAFT_URL}/build` }>Build</a>
+              </li>
+              <li className={ style['p-navigation__link'] } role="menuitem">
+                <a href="https://docs.snapcraft.io">Docs</a>
+              </li>
+              <li className={ style['p-navigation__link'] } role="menuitem">
+                <a className={ style['p-link--external'] } href="https://forum.snapcraft.io/categories">Forum</a>
+              </li>
+            </ul>
+            { authenticated
+              ? (
+                <ul className={ style['p-navigation__links--right'] } role="menu">
+                  <li className={ style['p-navigation__link'] } role="menuitem">
+                    <a className={ style['p-dropdown__toggle'] } aria-controls="account-menu" aria-expanded={ this.state.showUserDropdown }
+                      onClick={ this.onDropdownClick.bind(this)}
+                    >
+                      {user.name || user.login}<IconChevron className={ style['p-nav-icon'] }/>
+                    </a>
+                    <ul className={ style['p-dropdown__menu'] } id="account-menu" aria-hidden={ !this.state.showUserDropdown }>
+                      <li className={ style['p-navigation__link'] } role="menuitem">
+                        <a href={ `${SNAPCRAFT_URL}/account/snaps` } >My published snaps</a>
+                      </li>
+                      <li className={ style['p-navigation__link'] } role="menuitem">
+                        <a href={ `/user/${user.login}`} className={ style['is-selected'] }>Build with GitHub</a>
+                      </li>
+                      <li className={ style['p-navigation__link'] } role="menuitem">
+                        <a href={ `${SNAPCRAFT_URL}/account/details` }>Account details</a>
+                      </li>
+                      <li className={ style['p-navigation__link'] } role="menuitem">
+                        <a href="/auth/logout" onClick={ this.onLogoutClick.bind(this)}>Sign out</a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              ) : (
+                <ul className={ style['p-navigation__links--right'] } role="menu">
+                  <li className={ style['p-navigation__link'] } role="menuitem">
+                    <a href="/auth/authenticate">
+                      <IconUser className={ style['p-nav-icon'] }/>Developer account
+                    </a>
+                  </li>
+                </ul>
+              )
+            }
+          </nav>
         </div>
-        <nav className={ style['p-navigation__nav'] } role="menubar">
-          <ul className={ style['p-navigation__links'] } role="menu">
-            <li className={ style['p-navigation__link'] } role="menuitem">
-              <a href={ `${SNAPCRAFT_URL}/store` }>Store</a>
-            </li>
-            <li className={ style['p-navigation__link'] } role="menuitem">
-              <a href={ `${SNAPCRAFT_URL}/blog` }>Blog</a>
-            </li>
-            <li className={ style['p-navigation__link'] } role="menuitem">
-              <a href={ `${SNAPCRAFT_URL}/iot` }>IoT</a>
-            </li>
-            <li className={ style['p-navigation__link'] } role="menuitem">
-              <a className={ authenticated ? '' : style['is-selected'] } href={ `${SNAPCRAFT_URL}/build` }>Build</a>
-            </li>
-            <li className={ style['p-navigation__link'] } role="menuitem">
-              <a href="https://docs.snapcraft.io">Docs</a>
-            </li>
-            <li className={ style['p-navigation__link'] } role="menuitem">
-              <a className={ style['p-link--external'] } href="https://forum.snapcraft.io/categories">Forum</a>
-            </li>
-          </ul>
-          { authenticated
-            ? (
-              <ul className={ style['p-navigation__links--right'] } role="menu">
-                <li className={ style['p-navigation__link'] } role="menuitem">
-                  <a className={ style['p-dropdown__toggle'] } aria-controls="account-menu" aria-expanded={ this.state.showUserDropdown }
-                    onClick={ this.onDropdownClick.bind(this)}
-                  >
-                    {user.name || user.login}<IconChevron className={ style['p-nav-icon'] }/>
-                  </a>
-                  <ul className={ style['p-dropdown__menu'] } id="account-menu" aria-hidden={ !this.state.showUserDropdown }>
-                    <li className={ style['p-navigation__link'] } role="menuitem">
-                      <a href={ `${SNAPCRAFT_URL}/account/snaps` } >My published snaps</a>
-                    </li>
-                    <li className={ style['p-navigation__link'] } role="menuitem">
-                      <a href={ `/user/${user.login}`} className={ style['is-selected'] }>Build with GitHub</a>
-                    </li>
-                    <li className={ style['p-navigation__link'] } role="menuitem">
-                      <a href={ `${SNAPCRAFT_URL}/account/details` }>Account details</a>
-                    </li>
-                    <li className={ style['p-navigation__link'] } role="menuitem">
-                      <a href="/auth/logout" onClick={ this.onLogoutClick.bind(this)}>Sign out</a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            ) : (
-              <ul className={ style['p-navigation__links--right'] } role="menu">
-                <li className={ style['p-navigation__link'] } role="menuitem">
-                  <a href="/auth/authenticate">
-                    <IconUser className={ style['p-nav-icon'] }/>Developer account
-                  </a>
-                </li>
-              </ul>
-            )
-          }
-        </nav>
       </header>
     );
   }

--- a/src/common/containers/container.css
+++ b/src/common/containers/container.css
@@ -1,16 +1,15 @@
 .wrapper {
   box-sizing: border-box;
-  max-width: 1070px;
+  max-width: 1038px;
   margin: 0 auto;
-  padding: 0 1.25rem;
+  padding: 0;
   width: 100%;
 }
 
 .container {
   composes: wrapper;
   margin-bottom: 60px;
-  padding-bottom: 1rem;
-  padding-top: 1rem;
+  padding: 1rem 1.25rem;
 }
 
 .spinner {


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-websites/build.snapcraft.io/issues/1133

Also made the site have the same 'max-width' as snapcraft.io with the same padding for 'container' items, to help align the sites.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/auth/authenticate](http://0.0.0.0:8000/auth/authenticate)
- Click around and make sure no page width is broken.
- Resize the browser to make sure everything fits as expected
