### PR TITLE
Move "Build trigger" column before "Architecture"

### DIFF
--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -75,14 +75,14 @@ const BuildRow = (props) => {
           : <span>{`#${buildId}`}</span>
         }
       </Data>
+      <Data col="20">
+        { getBuildTriggerMessage(repository, reason, commitId) }
+      </Data>
       <Data col="15">
         {architecture}
       </Data>
       <Data col="15">
         {humanDuration}
-      </Data>
-      <Data col="20">
-        { getBuildTriggerMessage(repository, reason, commitId) }
       </Data>
       <Data col="35">
         <BuildStatus

--- a/src/common/components/builds-list/index.js
+++ b/src/common/components/builds-list/index.js
@@ -30,9 +30,9 @@ export const BuildsList = (props) => {
       <Head>
         <Row>
           <Header col="15">Number</Header>
+          <Header col="20">Build trigger</Header>
           <Header col="15">Architecture</Header>
           <Header col="15">Duration</Header>
-          <Header col="20">Build trigger</Header>
           <Header col="35">Result</Header>
         </Row>
       </Head>

--- a/test/unit/src/common/components/build-row/t_build-row.js
+++ b/test/unit/src/common/components/build-row/t_build-row.js
@@ -29,7 +29,7 @@ describe('<BuildRow />', function() {
 
     expect(element.find('Data').length).toBe(5);
 
-    const column = shallow(element.find(Data).get(3));
+    const column = shallow(element.find(Data).get(1));
     expect(column.html()).toInclude('Unknown');
   });
 
@@ -44,7 +44,7 @@ describe('<BuildRow />', function() {
 
       expect(element.find('Data').length).toBe(5);
 
-      const column = shallow(element.find(Data).get(3));
+      const column = shallow(element.find(Data).get(1));
       expect(column.html()).toInclude('Commit');
     });
 
@@ -59,7 +59,7 @@ describe('<BuildRow />', function() {
 
       expect(element.find('Data').length).toBe(5);
 
-      const column = shallow(element.find(Data).get(3));
+      const column = shallow(element.find(Data).get(1));
       expect(column.html()).toInclude('Commit');
       expect(column.find('a').length).toBe(1);
       expect(column.html()).toInclude('ab1234');


### PR DESCRIPTION
The "Build trigger" column is currently missing from the design
specification.  Design work for #556 calls for failed build requests to
have their request ID and error message rendered spanning the
"Architecture", "Duration", and "Result" columns; since failed build
requests still have a meaningful build trigger, having "Build trigger"
in the middle of this group of columns makes it hard to comply with that
otherwise-reasonable suggestion.

Moving "Build trigger" two columns to the left resolves this difficulty,
and seems to make just as much sense.  In fact, once we start using
build requests, it arguably makes more sense (because the build trigger
is known before the set of built-on architectures is known).