### PR TITLE
Simplify internalGetSnapBuilds return value

### DIFF
--- a/src/server/handlers/badge.js
+++ b/src/server/handlers/badge.js
@@ -22,8 +22,8 @@ export const badge = async (req, res) => {
 
     let badgeName = 'never_built';
 
-    if (builds.entries && builds.entries.length) {
-      const latestBuild = snapBuildFromAPI(builds.entries[0]);
+    if (builds.length) {
+      const latestBuild = snapBuildFromAPI(builds[0]);
 
       if (latestBuild.badge) {
         badgeName = latestBuild.badge;

--- a/src/server/scripts/poller.js
+++ b/src/server/scripts/poller.js
@@ -76,10 +76,8 @@ export const pollRepositories = (checker) => {
         try {
           const snap = await internalFindSnap(repositoryUrl);
           const builds = await internalGetSnapBuilds(snap, 0, 1);
-          // https://launchpad.net/+apidoc/devel.html#snap
-          // All builds of this snap package, sorted in descending order of
-          // finishing (or starting if not completed successfully).
-          const last_build = builds.entries[0];
+          // The most-recently-changed build or build request for this snap.
+          const last_build = builds[0];
 
           // TODO: builds won't be triggered if there are already previous ones
           // waiting in queue ('Needs Building' or 'Building').

--- a/test/routes/src/server/routes/t_badge.js
+++ b/test/routes/src/server/routes/t_badge.js
@@ -5,7 +5,7 @@ import proxyquire from 'proxyquire';
 
 const launchpadModule = {
   internalFindSnap: () => {},
-  internalGetSnapBuilds: () => {}
+  internalGetSnapBuilds: () => []
 };
 
 const badgeHandlerModule = proxyquire.noCallThru().load(
@@ -43,7 +43,7 @@ describe('The badge endpoint', () => {
       spyOnFindSnap.andThrow(new Error('Snap not found'));
     });
 
-    it('shoud return an error', async () => {
+    it('should return an error', async () => {
       await supertest(app).get('/badge/anowner/aname.svg').expect(404);
     });
   });
@@ -57,17 +57,14 @@ describe('The badge endpoint', () => {
 
     context('when there are builds for given repo', () => {
       beforeEach(() => {
-        spyOnGetBuilds.andReturn({
-          total_size: 1,
-          start: 0,
-          entries: [{
-            buildstate: 'Successfully built',
-            store_upload_status: 'Uploaded'
-          }]
-        });
+        spyOnGetBuilds.andReturn([{
+          resource_type_link: 'https://api.launchpad.net/devel/#snap_build',
+          buildstate: 'Successfully built',
+          store_upload_status: 'Uploaded'
+        }]);
       });
 
-      it('shoud return a 200 OK', async () => {
+      it('should return a 200 OK', async () => {
         await supertest(app).get('/badge/anowner/aname.svg').expect(200);
       });
 
@@ -83,18 +80,14 @@ describe('The badge endpoint', () => {
 
     context('when there are no builds for given repo', () => {
       beforeEach(() => {
-        spyOnGetBuilds.andReturn({
-          total_size: 0,
-          start: 0,
-          entries: []
-        });
+        spyOnGetBuilds.andReturn([]);
       });
 
-      it('shoud return a 200 OK', async () => {
+      it('should return a 200 OK', async () => {
         await supertest(app).get('/badge/anowner/aname.svg').expect(200);
       });
 
-      it('shoud return a SVG image with `never built` status', async () => {
+      it('should return a SVG image with `never built` status', async () => {
         const response = await supertest(app).get('/badge/anowner/aname.svg')
           .expect('Content-Type', 'image/svg+xml').buffer();
 

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -1719,7 +1719,8 @@ describe('The Launchpad API endpoint', () => {
           });
       });
 
-      it('should pass start and size params to builds_collection_link call', (done) => {
+      it('should pass start and size params to builds_collection_link ' +
+         'call', (done) => {
         // when getting builds list (via builds_collection_link)
         const lp = nock(lp_api_url)
           .get(lp_pending_builds_path)
@@ -1727,7 +1728,13 @@ describe('The Launchpad API endpoint', () => {
             'ws.start': 7,
             'ws.size': 42
           })
-          .reply(200, { entries: [] });
+          .reply(200, { total_size: 0, entries: [] })
+          .get(lp_completed_builds_path)
+          .query({
+            'ws.start': 7,
+            'ws.size': 42
+          })
+          .reply(200, { total_size: 0, entries: [] });
 
         supertest(app)
           .get('/launchpad/builds')

--- a/test/unit/src/server/scripts/t_poller.js
+++ b/test/unit/src/server/scripts/t_poller.js
@@ -115,7 +115,9 @@ describe('Poller script helpers', function() {
         lp.get(`/devel/~${LP_API_USERNAME}/+snap/a_snap/pending_builds`)
           .query({ 'ws.start': '0', 'ws.size': '1' })
           .reply(200, {
+            total_size: 1,
             entries: [{
+              resource_type_link: `${LP_API_URL}/devel/#snap_build`,
               datebuilt: since.format()
             }]
           });
@@ -131,7 +133,9 @@ describe('Poller script helpers', function() {
         lp.get(`/devel/~${LP_API_USERNAME}/+snap/a_snap/pending_builds`)
           .query({ 'ws.start': '0', 'ws.size': '1' })
           .reply(200, {
+            total_size: 1,
             entries: [{
+              resource_type_link: `${LP_API_URL}/devel/#snap_build`,
               datebuilt: since.format()
             }]
           });
@@ -160,7 +164,9 @@ describe('Poller script helpers', function() {
         lp.get(`/devel/~${LP_API_USERNAME}/+snap/a_snap/pending_builds`)
           .query({ 'ws.start': '0', 'ws.size': '1' })
           .reply(200, {
+            total_size: 1,
             entries: [{
+              resource_type_link: `${LP_API_URL}/devel/#snap_build`,
               datebuilt: since.format()
             }]
           });


### PR DESCRIPTION
`internalGetSnapBuilds` previously returned a somewhat mangled
`Collection` (a type used by the Launchpad web service client that
automatically handles batching and iteration of large collections).
However, this didn't make much sense here because the mangling meant
that the automatic batching wouldn't work quite right, and the callers
all just picked out the `entries` array anyway; it will make even less
sense as a `Collection` after upcoming work for #556.

We now just return an array instead.