### PR TITLE
Prepare UI for upcoming build request changes

### DIFF
--- a/src/common/components/build-request-row/index.js
+++ b/src/common/components/build-request-row/index.js
@@ -1,0 +1,74 @@
+import React, { PropTypes } from 'react';
+
+import { Row, Data } from '../vanilla/table-interactive';
+import { BuildStatusColours } from '../../helpers/snap-builds.js';
+import BuildStatus from '../build-status';
+
+import * as buildAnnotation from '../../helpers/build_annotation';
+
+const getBuildTriggerMessage = (repository, reason) => {
+  switch (reason) {
+    case buildAnnotation.BUILD_TRIGGERED_MANUALLY:
+      return 'Manual build';
+    case buildAnnotation.BUILD_TRIGGERED_BY_POLLER:
+      return 'Dependency change';
+    case buildAnnotation.BUILD_TRIGGERED_BY_WEBHOOK:
+      return 'Commit';
+    default:
+      return 'Unknown';
+  }
+};
+
+const BuildRequestRow = (props) => {
+
+  const {
+    repository,
+    buildId,
+    colour,
+    statusMessage,
+    dateCreated,
+    errorMessage,
+    reason
+  } = props;
+
+  return (
+    <Row key={ buildId }>
+      <Data col="15">
+        Requested
+      </Data>
+      <Data col="20">
+        { getBuildTriggerMessage(repository, reason) }
+      </Data>
+      <Data col="65">
+        { statusMessage === 'Failed to build' &&
+          <BuildStatus
+            colour={colour}
+            statusMessage={ `(Request #${buildId}) ${errorMessage}` }
+            dateStarted={dateCreated}
+          />
+        }
+      </Data>
+    </Row>
+  );
+};
+
+BuildRequestRow.defaultProps = {
+  isLinked: true
+};
+
+BuildRequestRow.propTypes = {
+  // params from URL
+  repository: PropTypes.shape({
+    fullName: PropTypes.string
+  }),
+
+  // build properties
+  buildId: PropTypes.string,
+  colour: PropTypes.oneOf(Object.values(BuildStatusColours)),
+  statusMessage: PropTypes.string,
+  dateCreated: PropTypes.string,
+  errorMessage: PropTypes.string,
+  reason: PropTypes.string
+};
+
+export default BuildRequestRow;

--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -42,6 +42,7 @@ const getBuildTriggerMessage = (repository, reason, commitId) => {
 const BuildRow = (props) => {
 
   const {
+    isRequest,
     repository,
     architecture,
     buildId,
@@ -49,6 +50,7 @@ const BuildRow = (props) => {
     duration,
     colour,
     statusMessage,
+    dateCreated,
     dateStarted,
     reason,
     commitId,
@@ -67,33 +69,57 @@ const BuildRow = (props) => {
     ? `/user/${repository.fullName}/${buildId}`
     : null;
 
-  return (
-    <Row key={ buildId }>
-      <Data col="15">
-        { buildUrl
-          ? <Link to={buildUrl}>{`#${buildId}`}</Link>
-          : <span>{`#${buildId}`}</span>
-        }
-      </Data>
-      <Data col="20">
-        { getBuildTriggerMessage(repository, reason, commitId) }
-      </Data>
-      <Data col="15">
-        {architecture}
-      </Data>
-      <Data col="15">
-        {humanDuration}
-      </Data>
-      <Data col="35">
-        <BuildStatus
-          link={buildUrl}
-          colour={colour}
-          statusMessage={statusMessage}
-          dateStarted={dateStarted}
-        />
-      </Data>
-    </Row>
+  const buildTriggerCell = (
+    <Data col="20">
+      { getBuildTriggerMessage(repository, reason, commitId) }
+    </Data>
   );
+
+  if (isRequest) {
+    return (
+      <Row key={ buildId }>
+        <Data col="15">
+          Requested
+        </Data>
+        { buildTriggerCell }
+        <Data col="65">
+          { statusMessage === 'Failed to build' &&
+            <BuildStatus
+              colour={colour}
+              statusMessage={ `(Request #${buildId}) ${statusMessage}` }
+              dateStarted={dateCreated}
+            />
+          }
+        </Data>
+      </Row>
+    );
+  } else {
+    return (
+      <Row key={ buildId }>
+        <Data col="15">
+          { buildUrl
+            ? <Link to={buildUrl}>{`#${buildId}`}</Link>
+            : <span>{`#${buildId}`}</span>
+          }
+        </Data>
+        { buildTriggerCell }
+        <Data col="15">
+          {architecture}
+        </Data>
+        <Data col="15">
+          {humanDuration}
+        </Data>
+        <Data col="35">
+          <BuildStatus
+            link={buildUrl}
+            colour={colour}
+            statusMessage={statusMessage}
+            dateStarted={dateStarted}
+          />
+        </Data>
+      </Row>
+    );
+  }
 };
 
 BuildRow.defaultProps = {
@@ -107,11 +133,13 @@ BuildRow.propTypes = {
   }),
 
   // build properties
-  buildId:  PropTypes.string,
+  isRequest: PropTypes.bool,
+  buildId: PropTypes.string,
   buildLogUrl: PropTypes.string,
   architecture: PropTypes.string,
   colour: PropTypes.oneOf(Object.values(BuildStatusColours)),
   statusMessage: PropTypes.string,
+  dateCreated: PropTypes.string,
   dateStarted: PropTypes.string,
   duration: PropTypes.string,
   reason: PropTypes.string,

--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -42,7 +42,6 @@ const getBuildTriggerMessage = (repository, reason, commitId) => {
 const BuildRow = (props) => {
 
   const {
-    isRequest,
     repository,
     architecture,
     buildId,
@@ -50,7 +49,6 @@ const BuildRow = (props) => {
     duration,
     colour,
     statusMessage,
-    dateCreated,
     dateStarted,
     reason,
     commitId,
@@ -69,57 +67,33 @@ const BuildRow = (props) => {
     ? `/user/${repository.fullName}/${buildId}`
     : null;
 
-  const buildTriggerCell = (
-    <Data col="20">
-      { getBuildTriggerMessage(repository, reason, commitId) }
-    </Data>
+  return (
+    <Row key={ buildId }>
+      <Data col="15">
+        { buildUrl
+          ? <Link to={buildUrl}>{`#${buildId}`}</Link>
+          : <span>{`#${buildId}`}</span>
+        }
+      </Data>
+      <Data col="20">
+        { getBuildTriggerMessage(repository, reason, commitId) }
+      </Data>
+      <Data col="15">
+        {architecture}
+      </Data>
+      <Data col="15">
+        {humanDuration}
+      </Data>
+      <Data col="35">
+        <BuildStatus
+          link={buildUrl}
+          colour={colour}
+          statusMessage={statusMessage}
+          dateStarted={dateStarted}
+        />
+      </Data>
+    </Row>
   );
-
-  if (isRequest) {
-    return (
-      <Row key={ buildId }>
-        <Data col="15">
-          Requested
-        </Data>
-        { buildTriggerCell }
-        <Data col="65">
-          { statusMessage === 'Failed to build' &&
-            <BuildStatus
-              colour={colour}
-              statusMessage={ `(Request #${buildId}) ${statusMessage}` }
-              dateStarted={dateCreated}
-            />
-          }
-        </Data>
-      </Row>
-    );
-  } else {
-    return (
-      <Row key={ buildId }>
-        <Data col="15">
-          { buildUrl
-            ? <Link to={buildUrl}>{`#${buildId}`}</Link>
-            : <span>{`#${buildId}`}</span>
-          }
-        </Data>
-        { buildTriggerCell }
-        <Data col="15">
-          {architecture}
-        </Data>
-        <Data col="15">
-          {humanDuration}
-        </Data>
-        <Data col="35">
-          <BuildStatus
-            link={buildUrl}
-            colour={colour}
-            statusMessage={statusMessage}
-            dateStarted={dateStarted}
-          />
-        </Data>
-      </Row>
-    );
-  }
 };
 
 BuildRow.defaultProps = {
@@ -133,13 +107,11 @@ BuildRow.propTypes = {
   }),
 
   // build properties
-  isRequest: PropTypes.bool,
   buildId: PropTypes.string,
   buildLogUrl: PropTypes.string,
   architecture: PropTypes.string,
   colour: PropTypes.oneOf(Object.values(BuildStatusColours)),
   statusMessage: PropTypes.string,
-  dateCreated: PropTypes.string,
   dateStarted: PropTypes.string,
   duration: PropTypes.string,
   reason: PropTypes.string,

--- a/src/common/components/builds-list/index.js
+++ b/src/common/components/builds-list/index.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 
+import BuildRequestRow from '../build-request-row';
 import BuildRow from '../build-row';
 import { Table, Head, Body, Row, Header } from '../vanilla/table-interactive';
 import Notification from '../vanilla-modules/notification';
@@ -21,13 +22,21 @@ export const BuildsList = (props) => {
 
   const buildRows = builds
     .sort((a,b) => ((+b.buildId) - (+a.buildId)))
-    .map((build) => (
-      <BuildRow
-        key={ build.isRequest ? `request_${build.buildId}` : build.buildId }
-        {...build}
-        repository={repository}
-      />
-    ));
+    .map((build) => {
+      if (build.isRequest) {
+        return (
+          <BuildRequestRow
+            key={ `request_${build.buildId}` }
+            {...build}
+            repository={repository}
+          />
+        );
+      } else {
+        return (
+          <BuildRow key={build.buildId} {...build} repository={repository} />
+        );
+      }
+    });
 
   return (
     <Table>

--- a/src/common/components/builds-list/index.js
+++ b/src/common/components/builds-list/index.js
@@ -22,7 +22,11 @@ export const BuildsList = (props) => {
   const buildRows = builds
     .sort((a,b) => ((+b.buildId) - (+a.buildId)))
     .map((build) => (
-      <BuildRow key={build.buildId} {...build} repository={repository} />
+      <BuildRow
+        key={ build.isRequest ? `request_${build.buildId}` : build.buildId }
+        {...build}
+        repository={repository}
+      />
     ));
 
   return (

--- a/src/common/reducers/snap-builds.js
+++ b/src/common/reducers/snap-builds.js
@@ -1,9 +1,14 @@
 import * as ActionTypes from '../actions/snap-builds';
-import { snapBuildFromAPI, annotateSnapBuild } from '../helpers/snap-builds';
+import {
+  annotateSnapBuild,
+  snapBuildFromAPI
+} from '../helpers/snap-builds';
 
 export const getAnnotatedBuilds = (action) => {
   const payload = action.payload.response.payload;
-  return payload.builds.map(snapBuildFromAPI).map(annotateSnapBuild(payload.build_annotations));
+  return payload.builds.map(snapBuildFromAPI).map(annotateSnapBuild(
+    payload.build_annotations, payload.build_request_annotations
+  ));
 };
 
 export const snapBuildsInitialStatus = {
@@ -53,7 +58,9 @@ export function snapBuilds(state = {}, action) {
           ...state[action.payload.id],
           isFetching: false,
           success: true,
-          builds: getAnnotatedBuilds(action).concat(state[action.payload.id].builds),
+          builds: getAnnotatedBuilds(action).concat(
+            state[action.payload.id].builds
+          ),
           error: null
         }
       };

--- a/test/unit/src/common/components/build-request-row/t_build-request-row.js
+++ b/test/unit/src/common/components/build-request-row/t_build-request-row.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import expect from 'expect';
+import { shallow } from 'enzyme';
+
+import BuildRequestRow from '../../../../../../src/common/components/build-request-row';
+import { BUILD_TRIGGER_UNKNOWN, BUILD_TRIGGERED_BY_WEBHOOK } from '../../../../../../src/common/helpers/build_annotation';
+
+describe('<BuildRequestRow />', function() {
+  const TEST_BUILD_REQUEST = {
+    isRequest: true,
+    buildId: '123456',
+    statusMessage: 'Building soon',
+    colour: 'grey',
+    dateCreated: '2016-11-09T17:05:52.436792+00:00',
+    errorMessage: null,
+    reason: BUILD_TRIGGER_UNKNOWN
+  };
+  const TEST_REPO = {
+    fullName: 'anowner/aname'
+  };
+
+  let element;
+
+  it('should display pending build request', () => {
+    element = shallow(
+      <BuildRequestRow repository={TEST_REPO} {...TEST_BUILD_REQUEST} />
+    );
+
+    const dataRows = element.find('Data');
+    expect(dataRows.length).toBe(3);
+    expect(shallow(dataRows.get(0)).text()).toEqual('Requested');
+    expect(shallow(dataRows.get(1)).text()).toEqual('Unknown');
+    expect(shallow(dataRows.get(2)).text()).toEqual('');
+  });
+
+  it('should display build reason', () => {
+    const request = {
+      ...TEST_BUILD_REQUEST,
+      reason: BUILD_TRIGGERED_BY_WEBHOOK
+    };
+
+    element = shallow(<BuildRequestRow repository={TEST_REPO} {...request} />);
+
+    const dataRows = element.find('Data');
+    expect(dataRows.length).toBe(3);
+    expect(shallow(dataRows.get(1)).text()).toEqual('Commit');
+  });
+
+  it('should display failed build request', () => {
+    const request = {
+      ...TEST_BUILD_REQUEST,
+      statusMessage: 'Failed to build',
+      errorMessage: 'Boom'
+    };
+
+    element = shallow(<BuildRequestRow repository={TEST_REPO} {...request} />);
+
+    const dataRows = element.find('Data');
+    expect(dataRows.length).toBe(3);
+    expect(shallow(dataRows.get(0)).text()).toEqual('Requested');
+    expect(shallow(dataRows.get(1)).text()).toEqual('Unknown');
+    expect(shallow(dataRows.get(2)).html()).toInclude(
+      '(Request #123456) Boom'
+    );
+  });
+});

--- a/test/unit/src/common/components/build-row/t_build-row.js
+++ b/test/unit/src/common/components/build-row/t_build-row.js
@@ -9,13 +9,23 @@ import { BUILD_TRIGGER_UNKNOWN, BUILD_TRIGGERED_BY_WEBHOOK } from '../../../../.
 
 describe('<BuildRow />', function() {
   const TEST_BUILD = {
-    buildId:  '1234',
+    isRequest: false,
+    buildId: '1234',
     buildLogUrl: 'http://example.com/12344567890_BUILDING.txt.gz',
     architecture: 'arch',
     colour: 'green',
     statusMessage: 'Build test status',
     dateStarted: '2017-03-07T12:29:45.297305+00:00',
     duration: '0:01:24.425045',
+    reason: BUILD_TRIGGER_UNKNOWN
+  };
+  const TEST_BUILD_REQUEST = {
+    isRequest: true,
+    buildId: '123456',
+    statusMessage: 'Building soon',
+    colour: 'grey',
+    dateCreated: '2016-11-09T17:05:52.436792+00:00',
+    errorMessage: null,
     reason: BUILD_TRIGGER_UNKNOWN
   };
   const TEST_REPO = {
@@ -125,5 +135,17 @@ describe('<BuildRow />', function() {
       expect(element.find('BuildStatus').length).toBe(1);
       expect(element.find('BuildStatus').prop('link')).toBe(null);
     });
+  });
+
+  it('should display pending build request', () => {
+    element = shallow(
+      <BuildRow repository={TEST_REPO} {...TEST_BUILD_REQUEST} />
+    );
+
+    const dataRows = element.find('Data');
+    expect(dataRows.length).toBe(3);
+    expect(shallow(dataRows.get(0)).text()).toEqual('Requested');
+    expect(shallow(dataRows.get(1)).text()).toEqual('Unknown');
+    expect(shallow(dataRows.get(2)).text()).toEqual('');
   });
 });

--- a/test/unit/src/common/components/build-row/t_build-row.js
+++ b/test/unit/src/common/components/build-row/t_build-row.js
@@ -19,15 +19,6 @@ describe('<BuildRow />', function() {
     duration: '0:01:24.425045',
     reason: BUILD_TRIGGER_UNKNOWN
   };
-  const TEST_BUILD_REQUEST = {
-    isRequest: true,
-    buildId: '123456',
-    statusMessage: 'Building soon',
-    colour: 'grey',
-    dateCreated: '2016-11-09T17:05:52.436792+00:00',
-    errorMessage: null,
-    reason: BUILD_TRIGGER_UNKNOWN
-  };
   const TEST_REPO = {
     fullName: 'anowner/aname'
   };
@@ -135,17 +126,5 @@ describe('<BuildRow />', function() {
       expect(element.find('BuildStatus').length).toBe(1);
       expect(element.find('BuildStatus').prop('link')).toBe(null);
     });
-  });
-
-  it('should display pending build request', () => {
-    element = shallow(
-      <BuildRow repository={TEST_REPO} {...TEST_BUILD_REQUEST} />
-    );
-
-    const dataRows = element.find('Data');
-    expect(dataRows.length).toBe(3);
-    expect(shallow(dataRows.get(0)).text()).toEqual('Requested');
-    expect(shallow(dataRows.get(1)).text()).toEqual('Unknown');
-    expect(shallow(dataRows.get(2)).text()).toEqual('');
   });
 });


### PR DESCRIPTION
We will shortly need to change new snap build requests to be dispatched
more asynchronously, in order that Launchpad can fetch `snapcraft.yaml`
from the repository and decide which architectures the snap should be
built for.  This means that a snap can be in a state where it has
pending build requests (different from pending builds: for instance,
they don't have an architecture), and also where it has failed build
requests in its history (for example, because `snapcraft.yaml` is
malformed in such a way that Launchpad can't determine which
architectures it should be built for).

This prepares the UI layer for that work by ensuring that it can
understand the modified server responses and render build requests in
the builds list.  The server side hasn't been changed yet (that will be
a follow-up PR), so this should result in no functional change for the
moment.

Build requests will be interleaved with builds in server responses, and
the UI tells them apart by looking at the `resource_type_link`.  This
wasn't my first choice for designing the internal API, but it turns out
to be the simplest option: in particular, if we want to be able to
support sensible pagination of the combined build and build request
history in future then we need to be iterating over a single collection.

Part of #556.