### PR TITLE
Return pending build requests from getSnapBuilds

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -76,8 +76,10 @@ To search for snap builds:
     GET /api/launchpad/builds?snap_link=:snap
     Accept: application/json
 
-On success, returns the following, where the items in `builds` are
+On success, returns the following, where the items in `builds` are either
 [snap\_build entries](https://launchpad.net/+apidoc/devel.html#snap_build)
+or
+[snap\_build\_request entries](https://launchpad.net/+apidoc/devel.html#snap_build_request)
 as returned by the Launchpad API:
 
     HTTP/1.1 200 OK

--- a/migrations/20180803154038_build-request-annotations.js
+++ b/migrations/20180803154038_build-request-annotations.js
@@ -1,0 +1,21 @@
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.createTable('build_request_annotation', function(table) {
+      table.integer('request_id').notNullable();
+      table.text('reason');
+      table.timestamps();
+      table.primary('request_id');
+    }).table('build_annotation', function(table) {
+      table.integer('request_id')
+        .references('build_request_annotation.request_id');
+    })
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('build_annotation', function(table) {
+      table.dropColumn('request_id');
+    }).dropTable('build_request_annotation')
+  ]);
+};

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -57,7 +57,9 @@ export class Builds extends Component {
   renderHelpBoxes() {
     const { snap } = this.props;
     const { builds } = this.props.snapBuilds;
-    const isPublished = builds.some((build) => build.isPublished);
+    const isPublished = builds.some(
+      (build) => !build.isRequest && build.isPublished
+    );
 
     if (snap && snap.storeName && isPublished) {
       return (
@@ -123,7 +125,14 @@ export class Builds extends Component {
   getLatestAndPreviousBuilds() {
     return this.props.snapBuilds.builds.reduce((builds, build) => {
       let { latest, previous } = builds;
-      if (latest.filter(b => b.architecture === build.architecture).length === 0) {
+      if (build.isRequest && build.statusMessage === 'Building soon') {
+        latest.push(build);
+      } else if (
+        !build.isRequest &&
+        latest.filter(
+          b => !b.isRequest && b.architecture === build.architecture
+        ).length === 0
+      ) {
         latest.push(build);
       } else {
         previous.push(build);

--- a/src/common/helpers/build_annotation.js
+++ b/src/common/helpers/build_annotation.js
@@ -10,8 +10,13 @@ const BUILD_TRIGGERED_BY_POLLER = 'triggered-by-poller';
 const BUILD_TRIGGER_UNKNOWN = 'trigger-unknown';
 
 
-function getBuildId(build) {
-  return parseInt(build.self_link.split('/').pop(), 10);
+function getLinkId(link) {
+  return parseInt(link.split('/').pop(), 10);
+}
+
+
+function getSelfId(entry) {
+  return getLinkId(entry.self_link);
 }
 
 
@@ -20,5 +25,6 @@ export {
   BUILD_TRIGGERED_BY_WEBHOOK,
   BUILD_TRIGGERED_BY_POLLER,
   BUILD_TRIGGER_UNKNOWN,
-  getBuildId
+  getLinkId,
+  getSelfId
 };

--- a/src/server/db/models/build_annotation.js
+++ b/src/server/db/models/build_annotation.js
@@ -1,12 +1,15 @@
-
 export default function register(db) {
   /* Schema:
    *   build_id: Launchpad build ID (unique)
-   *   reason: reason why the build was triggered.
+   *   reason: reason why the build was triggered
+   *   request: associated build request
    */
   db.model('BuildAnnotation', {
     tableName: 'build_annotation',
     idAttribute: 'build_id',
+    request: function() {
+      return this.belongsTo('BuildRequestAnnotation', 'request_id');
+    },
     hasTimestamps: true
   });
 }

--- a/src/server/db/models/build_request_annotation.js
+++ b/src/server/db/models/build_request_annotation.js
@@ -1,0 +1,15 @@
+export default function register(db) {
+  /* Schema:
+   *   request_id: Launchpad build request ID (unique)
+   *   reason: reason why the build request was issued
+   *   builds: all builds triggered as a result of this build request
+   */
+  db.model('BuildRequestAnnotation', {
+    tableName: 'build_request_annotation',
+    idAttribute: 'request_id',
+    builds: function() {
+      return this.hasMany('BuildAnnotation', 'request_id');
+    },
+    hasTimestamps: true
+  });
+}

--- a/src/server/db/models/index.js
+++ b/src/server/db/models/index.js
@@ -1,9 +1,11 @@
 import registerBuildAnnotation from './build_annotation';
+import registerBuildRequestAnnotation from './build_request_annotation';
 import registerGitHubUser from './github-user';
 import registerRepository from './repository';
 
 export default function register(db) {
   registerBuildAnnotation(db);
+  registerBuildRequestAnnotation(db);
   registerGitHubUser(db);
   registerRepository(db);
 }


### PR DESCRIPTION
This allows the UI to show the user that there's a pending build
request, rather than appearing unresponsive in the interval between a
set of builds being requested and the request being processed.

The database gains a new `build_request_annotation` table, allowing us
to keep track of build reasons even when the process of creating new
builds goes through a build request.

I'd like to return failed build requests as well, but there are some
significant complications involved in making that work efficiently in
conjunction with pagination, mainly on the Launchpad side.  I don't
think that needs to block the rest of this work.

Part of #556.

## QA

Since there's no way to create build requests from BSI yet, QA can consist of making sure that dispatching new builds still works and that the UI updates properly.