### PR TITLE
Extend webhook handler to support build requests

### DIFF
--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -1,6 +1,9 @@
 import { createHmac } from 'crypto';
 
-import { BUILD_TRIGGERED_BY_WEBHOOK } from '../../common/helpers/build_annotation';
+import {
+  BUILD_TRIGGERED_BY_WEBHOOK,
+  getLinkId
+} from '../../common/helpers/build_annotation';
 import { getGitHubRepoUrl } from '../../common/helpers/github-url';
 import db from '../db';
 import { conf } from '../helpers/config';
@@ -85,8 +88,36 @@ const handleGitHubPush = async (req, res, owner, name, parsedBody) => {
 };
 
 const handleLaunchpadSnapBuild = async (req, res, owner, name, parsedBody) => {
-  if (parsedBody.store_upload_status === 'Uploaded') {
-    try {
+  try {
+    if (parsedBody.action === 'created') {
+      await db.transaction(async (trx) => {
+        const dbRepository = await db.model('Repository')
+          .where({ owner, name })
+          .fetch({ withRelated: ['registrant'], transacting: trx });
+        const userQuery = (
+          (dbRepository && dbRepository.related('registrant')) ||
+          { login: owner }
+        );
+        await db.model('GitHubUser').incrementMetric(
+          userQuery, 'builds_requested', 1, { transacting: trx }
+        );
+      });
+
+      if (parsedBody.build_request_link !== null) {
+        // Record a build annotation so that we can determine why this build
+        // was dispatched.  As above, this is best-effort.
+        await db.transaction(async (trx) => {
+          await db.model('BuildAnnotation')
+            .forge({
+              build_id: getLinkId(parsedBody.snap_build_link),
+              request_id: getLinkId(parsedBody.build_request_link)
+            })
+            .save({}, { method: 'insert', transacting: trx });
+        });
+      }
+    }
+
+    if (parsedBody.store_upload_status === 'Uploaded') {
       await db.transaction(async (trx) => {
         const dbRepository = await db.model('Repository')
           .where({ owner, name })
@@ -99,10 +130,10 @@ const handleLaunchpadSnapBuild = async (req, res, owner, name, parsedBody) => {
           userQuery, 'builds_released', 1, { transacting: trx }
         );
       });
-    } catch (error) {
-      logger.error(error.message);
-      return res.status(500).send();
     }
+  } catch (error) {
+    logger.error(error.message);
+    return res.status(500).send();
   }
   return res.status(200).send();
 };


### PR DESCRIPTION
Launchpad sends a webhook when each build is created, and we now respond
to that by recording the link between the build and its parent build
request.

As is generally appropriate for webhooks, this is non-essential: if the
webhook delivery goes missing, we'll miss out on some metrics and won't
be able to present the correct build reason, but everything else will
still work.

Part of #556.