### PR TITLE
Extend poller to check pending build requests

### DIFF
--- a/src/server/scripts/poller.js
+++ b/src/server/scripts/poller.js
@@ -75,13 +75,20 @@ export const pollRepositories = (checker) => {
         const repositoryUrl = getGitHubRepoUrl(owner, name);
         try {
           const snap = await internalFindSnap(repositoryUrl);
-          const builds = await internalGetSnapBuilds(snap, 0, 1);
+          const builds = await internalGetSnapBuilds(
+            snap, 0, 1, { withRequests: true }
+          );
           // The most-recently-changed build or build request for this snap.
           const last_build = builds[0];
 
           // TODO: builds won't be triggered if there are already previous ones
           // waiting in queue ('Needs Building' or 'Building').
-          const last_built_at = last_build.datebuilt || last_build.datecreated;
+          let last_built_at;
+          if (last_build.resource_type_link.endsWith('#snap_build_request')) {
+            last_built_at = last_build.date_requested;
+          } else {
+            last_built_at = last_build.datebuilt || last_build.datecreated;
+          }
           if (!last_built_at) {
             throw new Error('LP last build timestamps are inconsistent.');
           }


### PR DESCRIPTION
If a build request is pending for a snap, we skip triggering new builds
just as we do if there have been recent builds.

Part of #556.