### PR TITLE
Fix LP webhook handling of build creation

### DIFF
--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -103,14 +103,14 @@ const handleLaunchpadSnapBuild = async (req, res, owner, name, parsedBody) => {
         );
       });
 
-      if (parsedBody.build_request_link !== null) {
+      if (parsedBody.build_request) {
         // Record a build annotation so that we can determine why this build
         // was dispatched.  As above, this is best-effort.
         await db.transaction(async (trx) => {
           await db.model('BuildAnnotation')
             .forge({
-              build_id: getLinkId(parsedBody.snap_build_link),
-              request_id: getLinkId(parsedBody.build_request_link)
+              build_id: getLinkId(parsedBody.snap_build),
+              request_id: getLinkId(parsedBody.build_request)
             })
             .save({}, { method: 'insert', transacting: trx });
         });

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -467,9 +467,9 @@ describe('The WebHook API endpoint', () => {
 
       context('if action is created', () => {
         const body = JSON.stringify({
-          snap_build_link: `${lp_api_base}${lp_snap_path}/+build/2`,
+          snap_build: `${lp_api_base}${lp_snap_path}/+build/2`,
           action: 'created',
-          build_request_link: `${lp_api_base}${lp_snap_path}/+build-request/1`
+          build_request: `${lp_api_base}${lp_snap_path}/+build-request/1`
         });
         let signature;
 


### PR DESCRIPTION
Unlike the webservice API, keys in the webhook payload that contain URL
paths don't have "_link" appended to their names.  (I managed to get
this wrong despite having written both ends of the protocol.)

Unfortunately this is very hard to QA locally, since the webhook endpoint generally isn't accessible from LP instances, but you can compare against the [documentation](https://help.launchpad.net/API/Webhooks#Snap_build).