### PR TITLE
Fix iteration of builds collections

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -696,13 +696,15 @@ export async function internalGetSnapBuilds(
     );
     for await (const buildRequest of buildRequests) {
       builds.push(buildRequest);
+      if (++gotItems >= size) {
+        break;
+      }
     }
     // XXX cjwatson 2018-10-01: We should also include previously-failed
     // build requests, since they might fail for reasons that the developer
     // needs to fix (e.g. malformed snapcraft.yaml).  Doing this in a
     // pagination-friendly way requires further work on the Launchpad APIs
     // we're using.
-    gotItems += buildRequests.total_size;
   }
 
   if (gotItems < size) {
@@ -711,8 +713,10 @@ export async function internalGetSnapBuilds(
     );
     for await (const build of pendingBuilds) {
       builds.push(build);
+      if (++gotItems >= size) {
+        break;
+      }
     }
-    gotItems += pendingBuilds.total_size;
   }
 
   if (gotItems < size) {
@@ -721,6 +725,9 @@ export async function internalGetSnapBuilds(
     );
     for await (const build of completedBuilds) {
       builds.push(build);
+      if (++gotItems >= size) {
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
I made a mistake while adding support for build requests: iterating over
a builds collection response from Launchpad iterates over the whole
collection, not just the current batch, so we ended up trying to return
all builds that had ever been created for a given snap and thus often
timing out.  We now take care to stop iterating once we've accumulated
enough builds.