### PR TITLE
Add ppc64el and s390x builds

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -35,7 +35,7 @@ import { getSnapcraftYamlCacheId } from './github';
 // configurable.
 const DISTRIBUTION = 'ubuntu';
 const DISTRO_SERIES = 'xenial';
-const ARCHITECTURES = ['amd64', 'arm64', 'armhf', 'i386'];
+const ARCHITECTURES = ['amd64', 'arm64', 'armhf', 'i386', 'ppc64el', 's390x'];
 
 const RESPONSE_NOT_LOGGED_IN = {
   status: 'error',

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -168,7 +168,9 @@ describe('The Launchpad API endpoint', () => {
                 '/+processors/amd64',
                 '/+processors/arm64',
                 '/+processors/armhf',
-                '/+processors/i386'
+                '/+processors/i386',
+                '/+processors/ppc64el',
+                '/+processors/s390x'
               ]
             }))
             .reply(201, 'Created', { Location: snapUrl });


### PR DESCRIPTION
I did this a while back for everything on production, but forgot that
we'd also need to do this for newly-registered snaps.