### PR TITLE
.gitignore environments/dev.env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ version-info.txt
 
 # Environment variables
 environments/development.env
+environments/dev.env
 
 # Development and test SQLite databases
 /dev.sqlite3


### PR DESCRIPTION
## Done

The README says to use `environments/dev.env` but the `.gitignore` only ignores `environments/development.env`. This add's `dev.env` to the `.gitignore` for new users and leaves `development.env` ignored for anyone that still uses that file.

As seen here: https://github.com/canonical-websites/build.snapcraft.io/pull/1129#pullrequestreview-143883946