### PR TITLE
If in development, don't redirect to snapcraft.io

### DIFF
--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -146,7 +146,11 @@ export const logout = (req, res, next) => {
     if (err) {
       return next(new Error('Failed to log out.'));
     }
-    // FIXME redirect to page that initiated the sign in request
-    res.redirect(`${SNAPCRAFT_URL}/logout?no_redirect=true`);
+    if (process.env.NODE_ENV !== 'development') {
+      res.redirect(`${SNAPCRAFT_URL}/logout?no_redirect=true`);
+    } else {
+      // FIXME redirect to page that initiated the sign in request
+      res.redirect('/');
+    }
   });
 };

--- a/src/server/handlers/login.js
+++ b/src/server/handlers/login.js
@@ -118,8 +118,12 @@ export const logout = (req, res, next) => {
       // TODO log errors to sentry
       return next(new Error(constants.E_LOGOUT_FAIL));
     }
-    // FIXME redirect to page that initiated the sign in request
-    res.redirect('/');
+    if (process.env.NODE_ENV !== 'development') {
+      res.redirect(`${SNAPCRAFT_URL}/logout?no_redirect=true`);
+    } else {
+      // FIXME redirect to page that initiated the sign in request
+      res.redirect('/');
+    }
   });
 };
 

--- a/src/server/routes/universal.js
+++ b/src/server/routes/universal.js
@@ -4,7 +4,9 @@ import { universal, homepage } from '../handlers/universal';
 
 const router = Router();
 
-router.get('/', homepage);
+if (process.env.NODE_ENV !== 'development') {
+  router.get('/', homepage);
+}
 router.get('*', universal);
 
 export default router;


### PR DESCRIPTION
## Done

When `NODE_ENV=devleopment`:
- Don't redirect `/` to (staging.)snapcraft.io/build
- On log out don't redirect to (staging.)snapcraft.io/logout

## QA

- Check out this feature branch
- Ensure you have `NODE_ENV=development` set in `environments/dev.env`
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- You should see the original build homepage (no redirect)
- Authenticate with Github using the green Github button on the homepage
- Once logged in, log out and you should be returned to the original build homepage (no redirect)


## Issue / Card
Fixes https://github.com/canonical-websites/build.snapcraft.io/issues/1153
