### PR TITLE
Redirect to login after session expired

### DIFF
--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -335,6 +335,16 @@ export function signAgreementSuccess() {
   return { type: SIGN_AGREEMENT_SUCCESS };
 }
 
+export function clearSession() {
+  return async (dispatch) => {
+    try {
+      await localforage.removeItem('package_upload_request');
+    } catch (error) {
+      dispatch(signOutError(error));
+    }
+  };
+}
+
 export function signOut(location) { // location for tests
   return async (dispatch) => {
     try {

--- a/src/common/components/session-overlay/index.js
+++ b/src/common/components/session-overlay/index.js
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import { signOut } from '../../actions/auth-store';
+import { clearSession } from '../../actions/auth-store';
+
+import { conf } from '../../helpers/config';
+const BASE_URL = conf.get('BASE_URL');
 
 import Notification from '../vanilla-modules/notification';
 
@@ -14,7 +17,7 @@ export class SessionOverlay extends Component {
   onReloadClick(event) {
     event.preventDefault();
     this.props.clearSession();
-    window.location.reload();
+    window.location.href = `${BASE_URL}/auth/authenticate`;
   }
 
   render() {
@@ -53,7 +56,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    clearSession: () => dispatch(signOut())
+    clearSession: () => dispatch(clearSession())
   };
 }
 

--- a/test/unit/src/common/actions/t_auth-store.js
+++ b/test/unit/src/common/actions/t_auth-store.js
@@ -28,6 +28,7 @@ const authStoreModule = proxyquire.noCallThru().load(
 
 const {
   checkSignedIntoStore,
+  clearSession,
   extractExpiresCaveat,
   extractSSOCaveat,
   getAccountInfo,
@@ -666,6 +667,40 @@ describe('store authentication actions', () => {
       expect(store.getActions()).toHaveActionOfType(
         ActionTypes.SIGN_AGREEMENT_SUCCESS
       );
+    });
+  });
+
+  context('clearSession', () => {
+    afterEach(() => {
+      localForageStub.clear();
+    });
+
+    context('when local storage throws an error', () => {
+      beforeEach(() => {
+        localForageStub.store['package_upload_request'] = new Error(
+          'Something went wrong!'
+        );
+      });
+
+      it('stores an error', async () => {
+        const expectedMessage = 'Something went wrong!';
+
+        await store.dispatch(clearSession());
+        const action = store.getActions().filter(
+          (a) => a.type === ActionTypes.SIGN_OUT_OF_STORE_ERROR)[0];
+        expect(action.payload.message).toBe(expectedMessage);
+      });
+    });
+
+    context('when local storage succeeds', () => {
+      beforeEach(() => {
+        localForageStub.store['package_upload_request'] = 'dummy';
+      });
+
+      it('removes the item', async () => {
+        await store.dispatch(clearSession());
+        expect(localForageStub.store).toExcludeKey('package_upload_request');
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #1146

When session expires instead of signing out and reloading the page (which results in redirect and sign out from snapcraft.io) we now just clear the session and redirect to /auth/authenticate, to sign user back in (they are likely still signed it to their GH account anyway).

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in (go to your repos page)
- Make your session expired ([make session shorter ](https://github.com/canonical-websites/build.snapcraft.io/blob/master/src/server/helpers/session.js#L11) or delete cookies)
- Click on 'Refresh the page' link on session expired warning
- You should be redirected back through GH auth to your repos page
