### PR TITLE
Set store series when creating a snap

### DIFF
--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -7,8 +7,9 @@ import url from 'url';
 
 import { checkStatus, getError, getMacaroonAuthHeader } from '../helpers/api';
 import { conf } from '../helpers/config';
+import { STORE_SERIES } from '../helpers/launchpad';
 import { getCaveats } from '../helpers/macaroons';
-import { STORE_SERIES, getPackageUploadRequestMacaroon } from './register-name';
+import { getPackageUploadRequestMacaroon } from './register-name';
 
 const BASE_URL = conf.get('BASE_URL');
 const STORE_API_URL = conf.get('STORE_API_URL');

--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -4,6 +4,7 @@ import { MacaroonsBuilder } from 'macaroons.js';
 
 import { APICompatibleError, checkStatus, getError, getMacaroonAuthHeader } from '../helpers/api';
 import { conf } from '../helpers/config';
+import { STORE_CHANNELS, STORE_SERIES } from '../helpers/launchpad';
 import { checkPackageUploadRequest, getAccountInfo } from './auth-store';
 import { requestBuilds } from './snap-builds';
 import { authExpired } from './auth-error';
@@ -16,11 +17,6 @@ export const REGISTER_NAME = 'REGISTER_NAME';
 export const REGISTER_NAME_SUCCESS = 'REGISTER_NAME_SUCCESS';
 export const REGISTER_NAME_ERROR = 'REGISTER_NAME_ERROR';
 export const REGISTER_NAME_CLEAR = 'REGISTER_NAME_CLEAR';
-
-// XXX cjwatson 2017-02-08: Hardcoded for now, but should eventually be
-// configurable.
-export const STORE_SERIES = '16';
-export const STORE_CHANNELS = ['edge'];
 
 export async function getPackageUploadRequestMacaroon() {
   let packageUploadRequest;

--- a/src/common/helpers/launchpad.js
+++ b/src/common/helpers/launchpad.js
@@ -1,0 +1,11 @@
+// Constants for use when interacting with Launchpad.
+
+// XXX cjwatson 2017-02-08: Hardcoded for now, but should eventually be
+// configurable.
+export const DISTRIBUTION = 'ubuntu';
+export const DISTRO_SERIES = 'xenial';
+export const ARCHITECTURES = [
+  'amd64', 'arm64', 'armhf', 'i386', 'ppc64el', 's390x'
+];
+export const STORE_SERIES = '16';
+export const STORE_CHANNELS = ['edge'];

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -11,6 +11,11 @@ import {
   getSelfId
 } from '../../common/helpers/build_annotation';
 import { parseGitHubRepoUrl } from '../../common/helpers/github-url';
+import {
+  ARCHITECTURES,
+  DISTRIBUTION,
+  DISTRO_SERIES
+} from '../../common/helpers/launchpad';
 import db from '../db';
 import { conf } from '../helpers/config';
 import { getMemcached } from '../helpers/memcached';
@@ -30,12 +35,6 @@ import { getLaunchpadRootSecret, makeWebhookSecret } from './webhook';
 const logger = logging.getLogger('express');
 
 import { getSnapcraftYamlCacheId } from './github';
-
-// XXX cjwatson 2016-12-08: Hardcoded for now, but should eventually be
-// configurable.
-const DISTRIBUTION = 'ubuntu';
-const DISTRO_SERIES = 'xenial';
-const ARCHITECTURES = ['amd64', 'arm64', 'armhf', 'i386', 'ppc64el', 's390x'];
 
 const RESPONSE_NOT_LOGGED_IN = {
   status: 'error',

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -14,7 +14,8 @@ import { parseGitHubRepoUrl } from '../../common/helpers/github-url';
 import {
   ARCHITECTURES,
   DISTRIBUTION,
-  DISTRO_SERIES
+  DISTRO_SERIES,
+  STORE_SERIES
 } from '../../common/helpers/launchpad';
 import db from '../db';
 import { conf } from '../helpers/config';
@@ -202,7 +203,8 @@ const requestNewSnap = (repositoryUrl) => {
       auto_build: false,
       auto_build_archive: `/${DISTRIBUTION}/+archive/primary`,
       auto_build_pocket: 'Updates',
-      processors: ARCHITECTURES.map((arch) => `/+processors/${arch}`)
+      processors: ARCHITECTURES.map((arch) => `/+processors/${arch}`),
+      store_series: `/+snappy-series/${STORE_SERIES}`
     }
   });
 };
@@ -659,6 +661,8 @@ export const authorizeSnap = async (req, res) => {
     const snapUrl = result.self_link;
     await getLaunchpad().patch(snapUrl, {
       store_upload: true,
+      // XXX cjwatson 2019-01-30: This can be removed once the change to set
+      // store_series when creating the snap has been deployed everywhere.
       store_series_link: `/+snappy-series/${series}`,
       store_name: snapName,
       store_channels: channels

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -162,8 +162,13 @@ describe('The Launchpad API endpoint', () => {
           lpApi
             .post('/devel/+snaps', (body) => tmatch(body, {
               ws: { op: 'new' },
+              owner: `/~${conf.get('LP_API_USERNAME')}`,
+              distro_series: '/ubuntu/xenial',
               git_repository_url: 'https://github.com/anowner/aname',
+              git_path: 'HEAD',
               auto_build: 'false',
+              auto_build_archive: '/ubuntu/+archive/primary',
+              auto_build_pocket: 'Updates',
               processors: [
                 '/+processors/amd64',
                 '/+processors/arm64',
@@ -171,7 +176,8 @@ describe('The Launchpad API endpoint', () => {
                 '/+processors/i386',
                 '/+processors/ppc64el',
                 '/+processors/s390x'
-              ]
+              ],
+              store_series: '/+snappy-series/16'
             }))
             .reply(201, 'Created', { Location: snapUrl });
           lpApi.get(`/devel/~test-user/+snap/${snapName}`)

--- a/test/unit/src/common/actions/t_auth-store.js
+++ b/test/unit/src/common/actions/t_auth-store.js
@@ -9,6 +9,7 @@ import tmatch from 'tmatch';
 import url from 'url';
 
 import { conf } from '../../../../../src/common/helpers/config';
+import { STORE_SERIES } from '../../../../../src/common/helpers/launchpad';
 import { makeLocalForageStub } from '../../../../helpers';
 
 const localForageStub = makeLocalForageStub();
@@ -16,7 +17,7 @@ const registerNameModule = proxyquire.noCallThru().load(
   '../../../../../src/common/actions/register-name',
   { 'localforage': localForageStub }
 );
-const { getPackageUploadRequestMacaroon, STORE_SERIES } = registerNameModule;
+const { getPackageUploadRequestMacaroon } = registerNameModule;
 
 const authStoreModule = proxyquire.noCallThru().load(
   '../../../../../src/common/actions/auth-store',


### PR DESCRIPTION
We also set this in `authorizeSnap`, but setting it when we create the
snap in Launchpad makes some things a bit less confusing on the
Launchpad side: snaps created by build.snapcraft.io currently end up
sometimes being processed by an obsolete migration job to backfill
`store_series`, which is odd.