### PR TITLE
Stop configuring new snaps to build on xenial

### DIFF
--- a/src/common/helpers/launchpad.js
+++ b/src/common/helpers/launchpad.js
@@ -3,7 +3,6 @@
 // XXX cjwatson 2017-02-08: Hardcoded for now, but should eventually be
 // configurable.
 export const DISTRIBUTION = 'ubuntu';
-export const DISTRO_SERIES = 'xenial';
 export const ARCHITECTURES = [
   'amd64', 'arm64', 'armhf', 'i386', 'ppc64el', 's390x'
 ];

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -14,7 +14,6 @@ import { parseGitHubRepoUrl } from '../../common/helpers/github-url';
 import {
   ARCHITECTURES,
   DISTRIBUTION,
-  DISTRO_SERIES,
   STORE_SERIES
 } from '../../common/helpers/launchpad';
 import db from '../db';
@@ -194,8 +193,7 @@ const requestNewSnap = (repositoryUrl) => {
   return lpClient.named_post('/+snaps', 'new', {
     parameters: {
       owner: `/~${username}`,
-      distro_series: `/${DISTRIBUTION}/${DISTRO_SERIES}`,
-      name: `${makeSnapName(repositoryUrl)}-${DISTRO_SERIES}`,
+      name: `${makeSnapName(repositoryUrl)}`,
       git_repository_url: repositoryUrl,
       git_path: 'HEAD',
       // auto_build will be enabled later, once snapcraft.yaml exists and

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -163,7 +163,6 @@ describe('The Launchpad API endpoint', () => {
             .post('/devel/+snaps', (body) => tmatch(body, {
               ws: { op: 'new' },
               owner: `/~${conf.get('LP_API_USERNAME')}`,
-              distro_series: '/ubuntu/xenial',
               git_repository_url: 'https://github.com/anowner/aname',
               git_path: 'HEAD',
               auto_build: 'false',

--- a/test/unit/src/common/helpers/t_snap-builds.js
+++ b/test/unit/src/common/helpers/t_snap-builds.js
@@ -32,7 +32,7 @@ describe('snapBuildFromAPI helper', () => {
     'dependencies': null,
     'date_first_dispatched': '2016-11-09T17:06:00.003766+00:00',
     'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-    'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
+    'distro_series_link': null,
     'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/9590',
     'datecreated': '2016-11-09T17:05:52.436792+00:00',
     'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -28,7 +28,7 @@ const SNAP_BUILDS = [{
   'dependencies': null,
   'date_first_dispatched': '2016-11-09T17:06:00.003766+00:00',
   'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-  'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
+  'distro_series_link': null,
   'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/9590',
   'datecreated': '2016-11-09T17:05:52.436792+00:00',
   'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
@@ -54,7 +54,7 @@ const SNAP_BUILDS = [{
   'dependencies': null,
   'date_first_dispatched': '2016-06-06T16:40:54.059279+00:00',
   'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-  'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
+  'distro_series_link': null,
   'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1149',
   'datecreated': '2016-06-06T16:40:51.698805+00:00',
   'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
@@ -144,7 +144,7 @@ describe('snapBuilds reducers', () => {
   context('FETCH_SNAP_SUCCESS', () => {
     const SNAP = {
       gitRepoUrl: 'https://github.com/anowner/aname',
-      selfLink: 'https://api.launchpad.net/devel/~anowner/+snap/blahblah-xenial',
+      selfLink: 'https://api.launchpad.net/devel/~anowner/+snap/blahblah',
       storeName: 'test-snap-store-name'
     };
 

--- a/test/unit/src/common/reducers/t_snaps.js
+++ b/test/unit/src/common/reducers/t_snaps.js
@@ -13,12 +13,12 @@ describe('snaps reducers', () => {
 
   const SNAPS = [{
     gitRepoUrl: 'https://github.com/anowner/aname',
-    selfLink: 'https://api.launchpad.net/devel/~anowner/+snap/blahblah-xenial',
+    selfLink: 'https://api.launchpad.net/devel/~anowner/+snap/blahblah',
     storeName: 'test-snap-store-name'
   },
   {
     gitRepoUrl: 'https://github.com/anowner/anothername',
-    selfLink: 'https://api.launchpad.net/devel/~anowner/+snap/blahblahtest-xenial',
+    selfLink: 'https://api.launchpad.net/devel/~anowner/+snap/blahblahtest',
     storeName: 'test-snap-store-another-name'
   }];
 


### PR DESCRIPTION
Launchpad now supports inferring the correct series dynamically from
`snapcraft.yaml`.  By no longer hardcoding xenial, we gain `core18`
support.

We'll also need to remove the now-unnecessary `distro_series`
configuration from existing snaps, but I'll deal with that after this
has been deployed to production.

Fixes #1185.