### PR TITLE
Removed CDK reference from footer until further notice

### DIFF
--- a/src/common/components/footer/index.js
+++ b/src/common/components/footer/index.js
@@ -30,8 +30,6 @@ export default class Footer extends Component {
             </nav>
             <p>
               &copy; 2019 Canonical Ltd. <br/> Ubuntu and Canonical are registered trademarks of Canonical Ltd.
-              <br />
-              Powered by <a href="https://www.ubuntu.com/kubernetes">the Charmed Distribution of Kubernetes</a>
             </p>
             <p><small>
               <a


### PR DESCRIPTION
## Done

Currently, there is no usage of CDK or Kubernetes at all in the process of build.snapcraft.io. Until further notice, we are removing the reference.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Check the footer does not have any reference to CDK

## Screenshots

![image](https://user-images.githubusercontent.com/8167677/53229702-418fbc80-3685-11e9-9633-5c0f695c12ce.png)
