### PR TITLE
Add global nav

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,9 @@
   "name": "build.snapcraft.io",
   "version": "1.0.0",
   "dependencies": {
+    "@canonical/global-nav": {
+      "version": "2.0.3"
+    },
     "accepts": {
       "version": "1.3.3"
     },
@@ -1329,11 +1332,11 @@
     "strict-uri-encode": {
       "version": "1.1.0"
     },
-    "string_decoder": {
-      "version": "0.10.31"
-    },
     "string-width": {
       "version": "1.0.2"
+    },
+    "string_decoder": {
+      "version": "0.10.31"
     },
     "stringstream": {
       "version": "0.0.5"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/canonical-websites/build.snapcraft.io#readme",
   "dependencies": {
+    "@canonical/global-nav": "^2.0.3",
     "async-lock": "^1.0.0",
     "babel-polyfill": "^6.16.0",
     "body-parser": "^1.15.2",

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -2,9 +2,12 @@
 import '../../node_modules/normalize.css/normalize.css';
 import './style/base.css';
 
+import { createNav } from 'global-nav';
+
 import React from 'react';
 import { render } from 'react-dom';
 
 import Root from './root';
 
+createNav({ maxWidth: '64.875rem', showLogins: false });
 render(<Root />, document.getElementById('content'));

--- a/src/common/style/vanilla/css/footer.css
+++ b/src/common/style/vanilla/css/footer.css
@@ -539,14 +539,16 @@
 
 /* for sticky footer to work */
 html,
-body,
-.content {
-  height: 100%; }
+body {
+  min-height: 100vh; }
 
+body,
 .hasStickyFooter {
-  height: 100%;
   display: flex;
   flex-direction: column; }
+
+.hasStickyFooter {
+  flex-grow: 1; }
 
 .p-footer {
   background-color: #f7f7f7;

--- a/src/common/style/vanilla/css/navigation.css
+++ b/src/common/style/vanilla/css/navigation.css
@@ -104,7 +104,7 @@
     top: -.725rem; }
 
 .p-navigation {
-  background-color: #252525;
+  background-color: #333;
   border-bottom: 1px solid transparent;
   color: #f7f7f7;
   margin-top: 0;
@@ -509,7 +509,7 @@
     .p-navigation .p-navigation__links--right .p-navigation__link .is-selected,
     .p-navigation .p-navigation__links .p-navigation__item .is-selected,
     .p-navigation .p-navigation__links--right .p-navigation__item .is-selected {
-      background: #111111; }
+      background: #1f1f1f; }
     .p-navigation .p-navigation__links .p-navigation__link:last-of-type, .p-navigation .p-navigation__links--right .p-navigation__link:last-of-type, .p-navigation .p-navigation__links .p-navigation__item:last-of-type, .p-navigation .p-navigation__links--right .p-navigation__item:last-of-type {
       border-right: 1px solid transparent; } }
 
@@ -538,7 +538,7 @@
     .p-navigation .p-navigation__links--right .p-dropdown__toggle[aria-expanded="true"] i {
       transform: rotate(180deg); }
   .p-navigation .p-navigation__links--right .p-dropdown__menu {
-    background-color: #252525;
+    background-color: #333;
     margin: 0;
     padding: 0;
     display: none;

--- a/src/common/style/vanilla/footer.scss
+++ b/src/common/style/vanilla/footer.scss
@@ -26,15 +26,18 @@
 
 /* for sticky footer to work */
 html,
+body {
+  min-height: 100vh;
+}
+
 body,
-.content {
-  height: 100%;
+.hasStickyFooter {
+  display: flex;
+  flex-direction: column;
 }
 
 .hasStickyFooter {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
+  flex-grow: 1;
 }
 
 @import 'vanilla-framework/scss/_base_vertical-spacing.scss';

--- a/src/common/style/vanilla/navigation.scss
+++ b/src/common/style/vanilla/navigation.scss
@@ -1,7 +1,7 @@
 @import 'vanilla-framework/scss/_utilities_clearfix.scss';
 @import 'vanilla-framework/scss/_base_typography.scss';
 
-$color-navigation-background: #252525;
+$color-navigation-background: #333;
 
 // for external links in navigation
 @import 'vanilla-framework/scss/patterns_links.scss';
@@ -14,7 +14,7 @@ $color-navigation-background: #252525;
 
 .p-navigation {
   $navigation-border-color: transparent;
-  $navigation-hover-color: darken($color-navigation-background, 8%); // from #252525 to #111
+  $navigation-hover-color: darken($color-navigation-background, 8%);
 
   .p-navigation__logo {
     height: 3rem;

--- a/src/server/helpers/html.js
+++ b/src/server/helpers/html.js
@@ -105,7 +105,7 @@ export default class Html extends Component {
         </head>
         <body>
           { googleTagManagerNoScript }
-          <div id="content" className={ style.content } dangerouslySetInnerHTML={{ __html: content }}/>
+          <div id="content" className={ style.hasStickyFooter } dangerouslySetInnerHTML={{ __html: content }}/>
           {
             SENTRY_DSN_PUBLIC &&
             <script src="https://cdn.ravenjs.com/3.25.1/raven.min.js" crossOrigin="anonymous"></script>

--- a/webpack/loaders-config.js
+++ b/webpack/loaders-config.js
@@ -3,7 +3,11 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 module.exports = [
   {
     test: /\.js$/i,
-    exclude: /node_modules/,
+    // global-nav needs babel transpilation
+    exclude: function(modulePath) {
+      return /node_modules/.test(modulePath) &&
+        !/node_modules\/global-nav/.test(modulePath);
+    },
     loaders: ['babel'],
   },
   {


### PR DESCRIPTION
## Done

Adds Canonical global nav (and fixes related styling conflicts).

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Global nav should appear on top
- Open/close global nav 'Products' dropdown
- Navigate to different BSI pages, see if global nav works as expected
- Check if there are no styling issues, z-index problems, etc


## Issue / Card

Fixes #1183 

## Screenshots

<img width="1137" alt="screenshot 2019-03-08 at 12 14 47" src="https://user-images.githubusercontent.com/83575/54025853-1be1d780-419c-11e9-9a10-2db2322ffea8.png">

