### PR TITLE
Propely namespace all global-nav occurences

### DIFF
--- a/src/common/index.js
+++ b/src/common/index.js
@@ -2,7 +2,7 @@
 import '../../node_modules/normalize.css/normalize.css';
 import './style/base.css';
 
-import { createNav } from 'global-nav';
+import { createNav } from '@canonical/global-nav';
 
 import React from 'react';
 import { render } from 'react-dom';

--- a/webpack/loaders-config.js
+++ b/webpack/loaders-config.js
@@ -6,7 +6,7 @@ module.exports = [
     // global-nav needs babel transpilation
     exclude: function(modulePath) {
       return /node_modules/.test(modulePath) &&
-        !/node_modules\/global-nav/.test(modulePath);
+        !/node_modules\/@canonical\/global-nav/.test(modulePath);
     },
     loaders: ['babel'],
   },


### PR DESCRIPTION
## Done

#1202 added @canonical/global-nav as a dependency, but it was still imported as `global-nav` (without namespace) causing failures on clean deployments.
This PR fixes this by properly namespacing all occurrences of global-nav.

## QA

- Check out this feature branch
- `rm -rf node_modules`
- `npm install`
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Everything should build without errors, site with global nav should be displayed

