### PR TITLE
Make builds pages public again

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -595,10 +595,6 @@ export const findSnaps = async (req, res) => {
 };
 
 export const findSnap = async (req, res) => {
-  if (!req.session || !req.session.token) {
-    return res.status(401).send(RESPONSE_NOT_LOGGED_IN);
-  }
-
   try {
     const snap = await internalFindSnap(req.query.repository_url);
 


### PR DESCRIPTION
## Done

Removes session requirement from `findSnap` handler to make builds and build pages are accessible by non signed-in users.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Without signing in go directly to an existing repo or build page (/user/bartaz/example-repo /user/bartaz/example-repo/12345)
- Pages should load normally without 'Session expired' warning
- Sign in with GH account
- Go from 'My repos' to a repo or build page
- It should load normally
- Make your session expire (wait very long or remove session cookies)
- No warning should be shown, page should pool for build updates normally without any errors
- Go to 'My repos'
- Warning should show up that session expired (because this page requires it)


## Issue / Card

Fixes #1148 

## Screenshots

<img width="995" alt="Screenshot 2019-03-20 at 14 00 05" src="https://user-images.githubusercontent.com/83575/54685991-7d009800-4b18-11e9-8c9e-ca5d942e401a.png">

