### PR TITLE
Fix unnecessary builds

### DIFF
--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -131,7 +131,7 @@ async function getPackageUploadMacaroon(root, discharge, snapName) {
 }
 
 export function registerName(repository, snapName, options={}) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     const { fullName } = repository;
 
     dispatch({
@@ -166,7 +166,11 @@ export function registerName(repository, snapName, options={}) {
       });
       await checkStatus(response);
       await dispatch(registerNameSuccess(fullName, snapName));
-      if (options.requestBuilds) {
+
+      // only request builds if there are no builds in progress already
+      const builds = getState().snapBuilds[fullName];
+      const isFetchingBuilds = builds && builds.isFetching;
+      if (options.requestBuilds && !isFetchingBuilds) {
         await dispatch(requestBuilds(repository.url));
       }
     } catch (error) {

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -156,7 +156,8 @@ export class RepositoryRowView extends Component {
     const { authStore, snap } = this.props;
     const repository = parseGitHubRepoUrl(repositoryUrl);
     const { snapName, signAgreement } = this.state;
-    const requestBuilds = snapIsConfigured(snap);
+    // request builds only if the snap is fully configured and there is no name mismatch
+    const requestBuilds = snapIsConfigured(snap) && !snapNameIsMismatched(snap, snapName);
 
     this.props.nameActions.registerName(repository, snapName, {
       signAgreement: signAgreement ? authStore.userName : null,
@@ -468,8 +469,10 @@ export class RepositoryRowView extends Component {
   }
 }
 
-const snapNameIsMismatched = (snap) => {
-  const { snapcraftData, storeName } = snap;
+const snapNameIsMismatched = (snap, storeName) => {
+  const { snapcraftData } = snap;
+  storeName = storeName || snap.storeName;
+
   return snapIsConfigured(snap) && storeName && snapcraftData.name !== storeName;
 };
 

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -44,9 +44,7 @@ const mockStore = configureMockStore(middlewares);
 
 describe('register name actions', () => {
   const initialState = {
-    isFetching: false,
-    success: false,
-    error: null
+    snapBuilds: {}
   };
   const repository = {
     url: 'https://github.com/foo/bar',
@@ -287,6 +285,24 @@ describe('register name actions', () => {
             });
 
             context('if requesting builds', () => {
+              it('does not request builds when they are already in progress', async () => {
+                store = mockStore({
+                  ...initialState,
+                  snapBuilds: {
+                    [repository.fullName]: {
+                      isFetching: true
+                    }
+                  }
+                });
+
+                await store.dispatch(registerName(repository, 'test-snap', {
+                  requestBuilds: true
+                }));
+                const actions = store.getActions();
+                expect(actions).toInclude(expectedAction);
+                expect(actions).notToHaveActionOfType(FETCH_BUILDS_ERROR);
+              });
+
               it('stores success and error actions if requesting builds ' +
                  'fails', async () => {
                 scope


### PR DESCRIPTION
## Done

Makes sure unnecessary builds are not triggered after registering name:
- when builds are already in progress
- when name is mismatched (snapcraft.yaml name doesn't match registered name)

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Sign in and go to "My repos"
- Add a new repo (with snapcraft.yaml), register its name
- Builds should be triggered
- Go to builds list for this repository there should be only one build per architecture running (check latest and previous builds list as per #1205)
- Go back to My repos
- Change registered name of a snap to a name that doesn't match one from snapcraft.yaml
- "Name mismatch" should appear and no builds should be triggered


## Issue / Card

Fixes #1205
Fixes #1209

## Screenshots

<img width="1042" alt="Screenshot 2019-03-27 at 13 58 15" src="https://user-images.githubusercontent.com/83575/55077568-64ecc380-5098-11e9-8392-b2657cb2d271.png">

