### PR TITLE
Makes the repo listing error message more specific

### DIFF
--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -113,7 +113,7 @@ class RepositoriesHome extends Component {
     if (error) {
       const message = (error.json && error.json.payload)
         ? error.json.payload.message
-        : 'There was an error completing your request, please try again later.';
+        : 'Sorry, we had a problem listing your repos. Try again in a few minutes.';
       errorNotification = (
         <Notification appearance='negative'>{ message }</Notification>
       );


### PR DESCRIPTION
“Completing your request” is technically correct, but probably not how most users will think of the action of visiting this page.

## Done

- Changed the error message
- Nothing else